### PR TITLE
feat: expand spells API data and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,260 +1,282 @@
-# 🐉 Adventurers Guild API
+# Adventurers Guild API
 
-A fantasy-themed REST API built to teach backend testing, API automation, and quality engineering practices through a playful RPG scenario inspired by tabletop adventures.
+Fantasy-themed REST API built with Next.js to support learning and practice around backend testing, API automation, contract validation, and documentation.
 
----
+## Purpose
 
-## ⚔️ Project Purpose
-
-The main goal of this project is to provide a realistic backend system that students can interact with while learning:
+This project is designed to provide a stable API surface that can be used to practice:
 
 - API testing fundamentals
-- Backend quality validation
-- Test automation
-- API documentation
-- Contract validation
-- Response structure validation
+- Response and schema validation
+- Contract-first documentation
 - Error handling validation
-- CI-ready test execution
+- Automated API checks with tools like Postman, Newman, Playwright, and TypeScript
 
----
+## Base URLs
 
-## 🧙 Concept
+- Production: [https://adventurers-guild-api.vercel.app](https://adventurers-guild-api.vercel.app)
+- Local: `http://localhost:3000`
 
-The world revolves around a **Guild of Adventurers**, where characters possess classic RPG attributes:
+## Interactive Documentation
 
-| Attribute | Meaning                                  |
-| --------- | ---------------------------------------- |
-| STR       | Strength – Physical power                |
-| DEX       | Dexterity – Agility and reflexes         |
-| CON       | Constitution – Endurance and resilience  |
-| INT       | Intelligence – Reasoning and knowledge   |
-| WIS       | Wisdom – Awareness and perception        |
-| CHA       | Charisma – Influence and social presence |
+- ReDoc: [https://adventurers-guild-api.vercel.app/docs](https://adventurers-guild-api.vercel.app/docs)
+- OpenAPI file: [https://adventurers-guild-api.vercel.app/openapi.yaml](https://adventurers-guild-api.vercel.app/openapi.yaml)
 
----
+## Current API Surface
 
-## 🌍 Live API
+### `GET /api/attributes`
 
-Production API hosted on Vercel:
+Returns the six core RPG attributes with:
 
-```
+- `id`
+- `name`
+- `shortname`
+- `description`
+- `skills`
 
-[https://adventurers-guild-api.vercel.app](https://adventurers-guild-api.vercel.app)
+### `GET /api/skills`
 
-```
+Returns a lightweight skills list with:
 
-Example endpoint:
+- `id`
+- `name`
 
-```
+### `GET /api/skills/{identifier}`
 
-GET /api/attributes
+Returns detailed information for a single skill.
 
-```
+Supported identifiers:
 
-Full endpoint example:
+- numeric id, for example `/api/skills/1`
+- slug, for example `/api/skills/animal-handling`
+- normalized skill name, for example `/api/skills/stealth`
 
-```
+Response fields:
 
-[https://adventurers-guild-api.vercel.app/api/attributes](https://adventurers-guild-api.vercel.app/api/attributes)
+- `id`
+- `name`
+- `attribute`
+- `description`
+- `exampleofuse`
+- `commonclasses`
 
-```
+Returns `404` with `{ "error": "Skill not found" }` when the skill does not exist.
 
----
+### `GET /api/classes`
 
-## 📚 API Documentation
+Returns a lightweight classes list with:
 
-Interactive Swagger documentation:
+- `id`
+- `name`
 
-```
+Returns `500` with `{ "error": "Failed to fetch classes" }` if the query fails.
 
-[https://adventurers-guild-api.vercel.app/docs](https://adventurers-guild-api.vercel.app/docs)
+### `GET /api/classes/{identifier}`
 
-```
+Returns detailed information for a single class.
 
-The documentation allows users to:
+Supported identifiers:
 
-- Explore endpoints
-- Inspect request/response schemas
-- Test endpoints directly from the browser
-- Understand expected responses
+- numeric id, for example `/api/classes/12`
+- slug, for example `/api/classes/wizard`
+- normalized class name, for example `/api/classes/fighter`
 
----
+Response fields:
 
-## 🧩 Current Endpoints
+- `id`
+- `name`
+- `slug`
+- `description`
+- `role`
+- `hitdie`
+- `primaryattributes`
+- `recommendedskills`
+- `savingthrows`
+- `spellcasting`
+- `subclasses`
+- `levelprogression`
 
-### 📜 Attributes
+Returns:
 
-#### Get all attributes
+- `404` with `{ "error": "Class not found" }` when the class does not exist
+- `500` with `{ "error": "Failed to fetch class detail" }` if the query fails
 
-```
+### `GET /api/spells`
 
-GET /api/attributes
+Returns a lightweight spells list with:
 
-```
+- `id`
+- `name`
+- `level`
+- `levelLabel`
 
-Returns the list of RPG core attributes.
+Returns `500` with `{ "error": "Failed to fetch spells" }` if the query fails.
 
-Example response:
+### `GET /api/spells/{identifier}`
+
+Returns detailed information for a single spell.
+
+Supported identifiers:
+
+- numeric id, for example `/api/spells/18`
+- slug, for example `/api/spells/acid-splash`
+- normalized name, for example `/api/spells/alarm`
+
+Response fields:
+
+- `id`
+- `name`
+- `slug`
+- `source`
+- `school`
+- `level`
+- `levelLabel`
+- `castingTime`
+- `range`
+- `components`
+- `duration`
+- `description`
+- `classes`
+- `scaling`
+
+Returns:
+
+- `404` with `{ "error": "Spell not found" }` when the spell does not exist
+- `500` with `{ "error": "Failed to fetch spell detail" }` if the query fails
+
+## Example Responses
+
+Attribute list item:
 
 ```json
-[
-  {
-    "id": 1,
-    "name": "Strength",
-    "shortname": "STR",
-    "description": "Measures physical power and brute-force capability."
-  }
-]
+{
+  "id": 1,
+  "name": "Strength",
+  "shortname": "STR",
+  "description": "Measures physical power, carrying capacity, and effectiveness in brute-force actions such as lifting, pushing, and melee attacks.",
+  "skills": ["Athletics"]
+}
 ```
 
----
+Class detail:
 
-## 🏗️ Project Architecture
-
+```json
+{
+  "id": 12,
+  "name": "Wizard",
+  "slug": "wizard",
+  "description": "A learned arcane scholar who studies the inner workings of magic to prepare spells, master rituals, and wield unmatched magical versatility.",
+  "role": "caster",
+  "hitdie": 6,
+  "primaryattributes": ["INT"],
+  "recommendedskills": [
+    "Arcana",
+    "Investigation",
+    "History",
+    "Nature",
+    "Religion"
+  ],
+  "savingthrows": ["INT", "WIS"],
+  "spellcasting": {
+    "ability": "INT",
+    "usesSpellbook": true,
+    "canCastRituals": true
+  },
+  "subclasses": ["Evoker"]
+}
 ```
-adventurers-guild-api
-│
-├── public
-│   └── openapi.yaml
-│
-├── src
-│   ├── app
-│   │   ├── api
-│   │   │   └── attributes
-│   │   │       └── route.ts
-│   │   │
-│   │   └── docs
-│   │       └── page.tsx
-│   │
-│   ├── data
-│   │   └── attributes.ts
-│   │
-│   └── types
-│       └── attribute.ts
-│
-└── README.md
+
+Spell detail:
+
+```json
+{
+  "id": 18,
+  "name": "Alarm",
+  "slug": "alarm",
+  "source": "Player's Handbook",
+  "school": "Abjuration",
+  "level": 1,
+  "levelLabel": "Level 1",
+  "castingTime": "1 minute or Ritual",
+  "range": "30 feet",
+  "components": {
+    "verbal": true,
+    "somatic": true,
+    "material": true,
+    "materialDescription": "a bell and silver wire"
+  },
+  "duration": "8 hours",
+  "description": "You set an alarm against intrusion.",
+  "classes": ["Ranger", "Wizard"],
+  "scaling": null
+}
 ```
 
----
-
-## 🧭 Collaboration Workflows
-
-To keep discussions focused, this project is organized by workflow instead of by resource.
-
-Recommended durable threads:
-
-- API Tests
-- API Evolution
-- Database and Inserts
-- Contract and Documentation
-- Types and Domain Models
-- Technical Maintenance
-
-Detailed thread ownership rules and examples live in [docs/collaboration-workflows.md](docs/collaboration-workflows.md).
-
----
-
-## 🧰 Technologies Used
-
-- Next.js
-- TypeScript
-- Vercel
-- OpenAPI / Swagger
-- Swagger UI
-- Node.js
-
----
-
-## 🧪 Testing Ecosystem
-
-This API is designed to support testing with tools such as:
-
-- Postman
-- Newman
-- Playwright
-- JavaScript / TypeScript
-
-Students can practice:
-
-- response validation
-- schema validation
-- automated API testing
-- test scripting
-- pipeline integration
-
----
-
-## 🎓 Educational Context
-
-This API is used as part of a **Backend Test Automation course**, where students progressively learn how to:
-
-1. Understand backend concepts
-2. Perform API calls
-3. Write automated tests with Postman
-4. Build test scripts using JavaScript
-5. Automate tests using Playwright
-6. Validate API responses and data structures
-7. Integrate tests in CI pipelines
-
----
-
-## 🚀 Running the Project Locally
+## Local Development
 
 Clone the repository:
 
-```
+```bash
 git clone https://github.com/your-repo/adventurers-guild-api.git
+cd adventurers-guild-api
 ```
 
 Install dependencies:
 
-```
+```bash
 npm install
 ```
 
-Run the development server:
+Start the development server:
 
-```
+```bash
 npm run dev
 ```
 
-API:
+Useful local URLs:
 
+- API base: `http://localhost:3000/api`
+- Docs: `http://localhost:3000/docs`
+- OpenAPI file: `http://localhost:3000/openapi.yaml`
+
+## Project Structure
+
+```text
+adventurers-guild-api
+├── app
+│   ├── api
+│   │   ├── attributes
+│   │   ├── classes
+│   │   ├── skills
+│   │   └── spells
+│   ├── docs
+│   ├── lib
+│   └── types
+├── public
+│   └── openapi.yaml
+├── tests
+│   └── data
+└── README.md
 ```
-http://localhost:3000/api
-```
 
-Docs:
+## Notes For Documentation Work
 
-```
-http://localhost:3000/docs
-```
+This repository treats documentation as part of the public API contract. The documentation should always reflect:
 
----
+- the current route handlers
+- the current shared types in `app/types`
+- the real error messages returned by the API
+- the response shapes asserted in `tests/data`
 
-## 📖 Future Features
+## Technologies
 
-Planned expansions include:
+- Next.js
+- TypeScript
+- Neon serverless Postgres
+- OpenAPI 3.0
+- ReDoc
+- Playwright
 
-- Characters
-- Inventory system
-- Monsters
-- Quests
-- Equipment
-- Gold economy
-
-These features will introduce **complex business rules for testing scenarios**.
-
----
-
-## ⚡ Author
-
-Bruno Machado
-Software Quality Engineer & Mentor
-
----
-
-## 🛡️ License
+## License
 
 This project is available for educational use and experimentation.

--- a/app/api/spells/[identifier]/route.ts
+++ b/app/api/spells/[identifier]/route.ts
@@ -1,0 +1,157 @@
+import { getSql } from '@/app/lib/db';
+import { SpellDetail } from '@/app/types/spell';
+import { NextResponse } from 'next/server';
+
+interface RouteContext {
+  params: Promise<{
+    identifier: string;
+  }>;
+}
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function normalizeSpellValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+async function getSpellClasses(
+  sql: ReturnType<typeof getSql>,
+  spellId: number | string,
+) {
+  try {
+    return await sql`
+      SELECT classes.name
+      FROM spellclasses
+      INNER JOIN classes ON classes.id = spellclasses.classid
+      WHERE spellclasses.spellid = ${spellId}
+      ORDER BY classes.id
+    `;
+  } catch (error) {
+    console.warn('Failed to fetch spell classes:', error);
+    return [];
+  }
+}
+
+async function getSpellScaling(
+  sql: ReturnType<typeof getSql>,
+  spellId: number | string,
+) {
+  try {
+    return await sql`
+      SELECT characterlevel AS level, description
+      FROM spellscaling
+      WHERE spellid = ${spellId}
+      ORDER BY characterlevel
+    `;
+  } catch (error) {
+    console.warn('Failed to fetch spell scaling:', error);
+    return [];
+  }
+}
+
+export async function GET(_: Request, { params }: RouteContext) {
+  const { identifier } = await params;
+  const parsedId = Number(identifier);
+  const sql = getSql();
+
+  try {
+    let spellRows;
+
+    if (!Number.isNaN(parsedId)) {
+      spellRows = await sql`
+        SELECT
+          id,
+          name,
+          slug,
+          source,
+          school,
+          level,
+          levellabel,
+          castingtime,
+          range,
+          verbal,
+          somatic,
+          material,
+          materialdescription,
+          duration,
+          description
+        FROM spells
+        WHERE id = ${parsedId}
+      `;
+    } else {
+      const normalizedIdentifier = normalizeSpellValue(identifier);
+
+      spellRows = await sql`
+        SELECT
+          id,
+          name,
+          slug,
+          source,
+          school,
+          level,
+          levellabel,
+          castingtime,
+          range,
+          verbal,
+          somatic,
+          material,
+          materialdescription,
+          duration,
+          description
+        FROM spells
+        WHERE LOWER(name) = ${normalizedIdentifier}
+          OR LOWER(slug) = ${normalizedIdentifier}
+      `;
+    }
+
+    if (!spellRows || spellRows.length === 0) {
+      return NextResponse.json({ error: 'Spell not found' }, { status: 404 });
+    }
+
+    const spell = spellRows[0];
+
+    const classRows = await getSpellClasses(sql, spell.id);
+    const scalingRows = await getSpellScaling(sql, spell.id);
+
+    const formattedSpell: SpellDetail = {
+      id: toNumber(spell.id),
+      name: spell.name,
+      slug: spell.slug,
+      source: spell.source,
+      school: spell.school,
+      level: toNumber(spell.level),
+      levelLabel: spell.levellabel,
+      castingTime: spell.castingtime,
+      range: spell.range,
+      components: {
+        verbal: spell.verbal,
+        somatic: spell.somatic,
+        material: spell.material,
+        materialDescription: spell.materialdescription,
+      },
+      duration: spell.duration,
+      description: spell.description,
+      classes: classRows.map((row) => row.name),
+      scaling:
+        scalingRows.length > 0
+          ? {
+              entries: scalingRows.map((row) => ({
+                level: toNumber(row.level),
+                description: row.description,
+              })),
+            }
+          : null,
+    };
+
+    return NextResponse.json(formattedSpell, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch spell detail:', error);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch spell detail' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/spells/route.ts
+++ b/app/api/spells/route.ts
@@ -1,0 +1,35 @@
+import { getSql } from '@/app/lib/db';
+import { SpellListItem } from '@/app/types/spell';
+import { NextResponse } from 'next/server';
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+export async function GET() {
+  const sql = getSql();
+
+  try {
+    const spellRows = await sql`
+      SELECT id, name, level, levellabel
+      FROM spells
+      ORDER BY id
+    `;
+
+    const spells: SpellListItem[] = spellRows.map((spell) => ({
+      id: toNumber(spell.id),
+      name: spell.name,
+      level: toNumber(spell.level),
+      levelLabel: spell.levellabel,
+    }));
+
+    return NextResponse.json(spells, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch spells:', error);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch spells' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/types/spell.ts
+++ b/app/types/spell.ts
@@ -1,0 +1,39 @@
+export interface SpellListItem {
+  id: number;
+  name: string;
+  level: number;
+  levelLabel: string;
+}
+
+export interface SpellComponents {
+  verbal: boolean;
+  somatic: boolean;
+  material: boolean;
+  materialDescription: string | null;
+}
+
+export interface SpellScalingEntry {
+  level: number;
+  description: string;
+}
+
+export interface SpellScaling {
+  entries: SpellScalingEntry[];
+}
+
+export interface SpellDetail {
+  id: number;
+  name: string;
+  slug: string;
+  source: string;
+  school: string;
+  level: number;
+  levelLabel: string;
+  castingTime: string;
+  range: string;
+  components: SpellComponents;
+  duration: string;
+  description: string;
+  classes: string[];
+  scaling: SpellScaling | null;
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,22 +2,16 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.2.0
+  version: 1.3.0
   description: |
-    A fantasy-themed API designed for learning **backend testing** and **API automation**.
+    Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
-    This project is part of a testing-focused RPG domain and currently includes:
+    The documentation in this file reflects the current public routes implemented by the API:
 
-    - **Attributes** → core RPG attributes such as STR, DEX, and WIS
-    - **Skills** → simplified list and detailed lookup by id or slug
-    - **Classes** → simplified list of playable RPG classes
-
-    This API is ideal for practicing:
-    - API schema validation
-    - response assertions
-    - path parameter validation
-    - automated tests with Playwright
-    - OpenAPI-based documentation
+    - Attributes list
+    - Skills list and detail
+    - Classes list and detail
+    - Spells list and detail
 
 servers:
   - url: http://localhost:3000
@@ -29,9 +23,11 @@ tags:
   - name: Attributes
     description: Core RPG attributes such as Strength, Dexterity, and Wisdom.
   - name: Skills
-    description: Skills related to RPG attributes, including detail lookups.
+    description: Skills list and skill detail endpoints.
   - name: Classes
-    description: Playable RPG character classes.
+    description: Playable RPG classes, including detail payloads.
+  - name: Spells
+    description: Spell list and spell detail endpoints.
 
 x-tagGroups:
   - name: Core Resources
@@ -39,6 +35,7 @@ x-tagGroups:
       - Attributes
       - Skills
       - Classes
+      - Spells
 
 paths:
   /api/attributes:
@@ -48,10 +45,10 @@ paths:
       operationId: getAttributes
       summary: List all attributes
       description: |
-        Returns the six core RPG attributes with their descriptions and related skills.
+        Returns the six core RPG attributes with their descriptions and the skill names associated with each attribute.
       responses:
         '200':
-          description: Successful response
+          description: Attributes returned successfully
           content:
             application/json:
               schema:
@@ -73,40 +70,6 @@ paths:
                     - Acrobatics
                     - Sleight of Hand
                     - Stealth
-                - id: 3
-                  name: Constitution
-                  shortname: CON
-                  description: Measures endurance, resilience, and physical toughness. It is commonly associated with health, stamina, and resistance to harm.
-                  skills: []
-                - id: 4
-                  name: Intelligence
-                  shortname: INT
-                  description: Measures reasoning, memory, knowledge, and analytical ability. It is linked to learning, investigation, and logical thinking.
-                  skills:
-                    - Arcana
-                    - History
-                    - Investigation
-                    - Nature
-                    - Religion
-                - id: 5
-                  name: Wisdom
-                  shortname: WIS
-                  description: Measures perception, intuition, awareness, and good judgment. It reflects how well a character understands the world around them.
-                  skills:
-                    - Animal Handling
-                    - Insight
-                    - Medicine
-                    - Perception
-                    - Survival
-                - id: 6
-                  name: Charisma
-                  shortname: CHA
-                  description: Measures presence, confidence, influence, and social impact. It affects persuasion, leadership, and interpersonal interactions.
-                  skills:
-                    - Deception
-                    - Intimidation
-                    - Performance
-                    - Persuasion
 
   /api/skills:
     get:
@@ -115,14 +78,14 @@ paths:
       operationId: getSkills
       summary: List all skills
       description: |
-        Returns a simplified list of all available skills.
+        Returns a lightweight list of available skills.
 
-        This endpoint is intentionally lightweight and only exposes:
+        This endpoint exposes only:
         - `id`
         - `name`
       responses:
         '200':
-          description: Successful response
+          description: Skills returned successfully
           content:
             application/json:
               schema:
@@ -144,31 +107,31 @@ paths:
       tags:
         - Skills
       operationId: getSkillByIdentifier
-      summary: Get skill by id or name
+      summary: Get skill detail by identifier
       description: |
         Returns detailed information about a skill.
 
-        The `identifier` path parameter supports:
-        - numeric id → `/api/skills/1`
-        - slug name → `/api/skills/stealth`
-        - multi-word slug → `/api/skills/animal-handling`
+        Supported identifiers:
+        - numeric id, for example `/api/skills/1`
+        - slug, for example `/api/skills/animal-handling`
+        - normalized name, for example `/api/skills/stealth`
       parameters:
         - name: identifier
           in: path
           required: true
-          description: Skill identifier. Can be a numeric id or a slug name.
+          description: Skill identifier as numeric id, slug, or normalized name.
           schema:
             type: string
           examples:
             byId:
               summary: Search by id
               value: '1'
-            byName:
+            bySlug:
               summary: Search by slug
-              value: stealth
-            byComplexName:
-              summary: Search by multi-word slug
               value: animal-handling
+            byName:
+              summary: Search by normalized name
+              value: stealth
       responses:
         '200':
           description: Skill found successfully
@@ -177,8 +140,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/SkillDetail'
               examples:
-                byId:
-                  summary: Example response for Athletics
+                athletics:
+                  summary: Athletics detail
                   value:
                     id: 1
                     name: Athletics
@@ -189,18 +152,20 @@ paths:
                       - Fighter
                       - Barbarian
                       - Paladin
-                byName:
-                  summary: Example response for Stealth
+                      - Ranger
+                stealth:
+                  summary: Stealth detail
                   value:
                     id: 4
                     name: Stealth
                     attribute: DEX
-                    description: Represents the ability to move silently, remain unseen, and avoid detection.
-                    exampleofuse: Used when a character sneaks past guards or hides in the shadows.
+                    description: Represents the ability to move silently and remain unseen.
+                    exampleofuse: Used when sneaking past enemies or hiding.
                     commonclasses:
                       - Rogue
                       - Ranger
                       - Monk
+                      - Bard
         '404':
           description: Skill not found
           content:
@@ -217,16 +182,14 @@ paths:
       operationId: getClasses
       summary: List all classes
       description: |
-        Returns a simplified list of RPG classes.
+        Returns a lightweight list of RPG classes.
 
-        This endpoint currently exposes:
+        This endpoint exposes only:
         - `id`
         - `name`
-
-        Future versions may include detailed lookup endpoints for class information.
       responses:
         '200':
-          description: Successful response
+          description: Classes returned successfully
           content:
             application/json:
               schema:
@@ -235,20 +198,323 @@ paths:
                   $ref: '#/components/schemas/ClassListItem'
               example:
                 - id: 1
-                  name: Fighter
+                  name: Barbarian
                 - id: 2
-                  name: Wizard
+                  name: Bard
                 - id: 3
-                  name: Rogue
-                - id: 4
                   name: Cleric
-                - id: 5
-                  name: Ranger
-                - id: 6
-                  name: Paladin
+                - id: 4
+                  name: Druid
+        '500':
+          description: Failed to fetch classes
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch classes
+
+  /api/classes/{identifier}:
+    get:
+      tags:
+        - Classes
+      operationId: getClassByIdentifier
+      summary: Get class detail by identifier
+      description: |
+        Returns detailed information about a class.
+
+        Supported identifiers:
+        - numeric id, for example `/api/classes/12`
+        - slug, for example `/api/classes/wizard`
+        - normalized name, for example `/api/classes/fighter`
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          description: Class identifier as numeric id, slug, or normalized name.
+          schema:
+            type: string
+          examples:
+            byId:
+              summary: Search by id
+              value: '12'
+            bySlug:
+              summary: Search by slug
+              value: wizard
+            byName:
+              summary: Search by normalized name
+              value: fighter
+      responses:
+        '200':
+          description: Class found successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClassDetail'
+              examples:
+                fighter:
+                  summary: Fighter detail
+                  value:
+                    id: 5
+                    name: Fighter
+                    slug: fighter
+                    description: A master of weapons and armor who dominates the battlefield through martial skill, endurance, and tactical expertise.
+                    role: melee
+                    hitdie: 10
+                    primaryattributes:
+                      - STR
+                      - DEX
+                    recommendedskills:
+                      - Athletics
+                      - Perception
+                      - Intimidation
+                      - Survival
+                      - Acrobatics
+                    savingthrows:
+                      - STR
+                      - CON
+                    spellcasting: null
+                    subclasses:
+                      - Champion
+                    levelprogression: []
+                wizard:
+                  summary: Wizard detail
+                  value:
+                    id: 12
+                    name: Wizard
+                    slug: wizard
+                    description: A learned arcane scholar who studies the inner workings of magic to prepare spells, master rituals, and wield unmatched magical versatility.
+                    role: caster
+                    hitdie: 6
+                    primaryattributes:
+                      - INT
+                    recommendedskills:
+                      - Arcana
+                      - Investigation
+                      - History
+                      - Nature
+                      - Religion
+                    savingthrows:
+                      - INT
+                      - WIS
+                    spellcasting:
+                      ability: INT
+                      usesSpellbook: true
+                      canCastRituals: true
+                    subclasses:
+                      - Evoker
+                    levelprogression: []
+        '404':
+          description: Class not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Class not found
+        '500':
+          description: Failed to fetch class detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch class detail
+
+  /api/spells:
+    get:
+      tags:
+        - Spells
+      operationId: getSpells
+      summary: List all spells
+      description: |
+        Returns a lightweight list of spells.
+
+        This endpoint exposes:
+        - `id`
+        - `name`
+        - `level`
+        - `levelLabel`
+      responses:
+        '200':
+          description: Spells returned successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SpellListItem'
+              example:
+                - id: 1
+                  name: Acid Splash
+                  level: 0
+                  levelLabel: Cantrip
+                - id: 18
+                  name: Alarm
+                  level: 1
+                  levelLabel: Level 1
+                - id: 20
+                  name: Animal Friendship
+                  level: 1
+                  levelLabel: Level 1
+        '500':
+          description: Failed to fetch spells
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch spells
+
+  /api/spells/{identifier}:
+    get:
+      tags:
+        - Spells
+      operationId: getSpellByIdentifier
+      summary: Get spell detail by identifier
+      description: |
+        Returns detailed information about a spell.
+
+        Supported identifiers:
+        - numeric id, for example `/api/spells/18`
+        - slug, for example `/api/spells/acid-splash`
+        - normalized name, for example `/api/spells/alarm`
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          description: Spell identifier as numeric id, slug, or normalized name.
+          schema:
+            type: string
+          examples:
+            byId:
+              summary: Search by id
+              value: '18'
+            bySlug:
+              summary: Search by slug
+              value: acid-splash
+            byName:
+              summary: Search by normalized name
+              value: alarm
+      responses:
+        '200':
+          description: Spell found successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SpellDetail'
+              examples:
+                acidSplash:
+                  summary: Acid Splash detail
+                  value:
+                    id: 1
+                    name: Acid Splash
+                    slug: acid-splash
+                    source: Player's Handbook
+                    school: Evocation
+                    level: 0
+                    levelLabel: Cantrip
+                    castingTime: Action
+                    range: 60 feet
+                    components:
+                      verbal: true
+                      somatic: true
+                      material: false
+                      materialDescription: null
+                    duration: Instantaneous
+                    description: You create an acidic bubble at a point within range, where it explodes in a 5-foot-radius Sphere. Each creature in that Sphere must succeed on a Dexterity saving throw or take 1d6 Acid damage.
+                    classes:
+                      - Sorcerer
+                      - Wizard
+                    scaling:
+                      entries:
+                        - level: 5
+                          description: damage increases to 2d6
+                        - level: 11
+                          description: damage increases to 3d6
+                        - level: 17
+                          description: damage increases to 4d6
+                alarm:
+                  summary: Alarm detail
+                  value:
+                    id: 18
+                    name: Alarm
+                    slug: alarm
+                    source: Player's Handbook
+                    school: Abjuration
+                    level: 1
+                    levelLabel: Level 1
+                    castingTime: 1 minute or Ritual
+                    range: 30 feet
+                    components:
+                      verbal: true
+                      somatic: true
+                      material: true
+                      materialDescription: a bell and silver wire
+                    duration: 8 hours
+                    description: |
+                      You set an alarm against intrusion. Choose a door, a window, or an area within range that is no larger than a 20-foot Cube. Until the spell ends, an alarm alerts you whenever a creature touches or enters the warded area. When you cast the spell, you can designate creatures that won't set off the alarm. You also choose whether the alarm is audible or mental:
+
+                      Audible Alarm. The alarm produces the sound of a handbell for 10 seconds within 60 feet of the warded area.
+
+                      Mental Alarm. You are alerted by a mental ping if you are within 1 mile of the warded area. This ping awakens you if you're asleep.
+                    classes:
+                      - Ranger
+                      - Wizard
+                    scaling: null
+        '404':
+          description: Spell not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Spell not found
+        '500':
+          description: Failed to fetch spell detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch spell detail
 
 components:
   schemas:
+    AttributeShortname:
+      type: string
+      enum:
+        - STR
+        - DEX
+        - CON
+        - INT
+        - WIS
+        - CHA
+      example: STR
+
+    SkillName:
+      type: string
+      enum:
+        - Athletics
+        - Acrobatics
+        - Sleight of Hand
+        - Stealth
+        - Arcana
+        - History
+        - Investigation
+        - Nature
+        - Religion
+        - Animal Handling
+        - Insight
+        - Medicine
+        - Perception
+        - Survival
+        - Deception
+        - Intimidation
+        - Performance
+        - Persuasion
+      example: Athletics
+
     Attribute:
       type: object
       required:
@@ -265,23 +531,15 @@ components:
           type: string
           example: Strength
         shortname:
-          type: string
-          enum:
-            - STR
-            - DEX
-            - CON
-            - INT
-            - WIS
-            - CHA
-          example: STR
+          $ref: '#/components/schemas/AttributeShortname'
         description:
           type: string
           example: Measures physical power, carrying capacity, and effectiveness in brute-force actions such as lifting, pushing, and melee attacks.
         skills:
           type: array
-          description: List of skills related to the attribute.
+          description: List of skill names associated with the attribute.
           items:
-            type: string
+            $ref: '#/components/schemas/SkillName'
           example:
             - Athletics
 
@@ -295,8 +553,7 @@ components:
           type: integer
           example: 1
         name:
-          type: string
-          example: Athletics
+          $ref: '#/components/schemas/SkillName'
 
     SkillDetail:
       type: object
@@ -312,18 +569,9 @@ components:
           type: integer
           example: 1
         name:
-          type: string
-          example: Athletics
+          $ref: '#/components/schemas/SkillName'
         attribute:
-          type: string
-          enum:
-            - STR
-            - DEX
-            - CON
-            - INT
-            - WIS
-            - CHA
-          example: STR
+          $ref: '#/components/schemas/AttributeShortname'
         description:
           type: string
           example: Represents physical capability in actions such as climbing, jumping, swimming, or forcing objects through strength.
@@ -338,6 +586,17 @@ components:
             - Fighter
             - Barbarian
             - Paladin
+            - Ranger
+
+    ClassRole:
+      type: string
+      enum:
+        - melee
+        - caster
+        - support
+        - stealth
+        - hybrid
+      example: caster
 
     ClassListItem:
       type: object
@@ -347,10 +606,253 @@ components:
       properties:
         id:
           type: integer
+          example: 12
+        name:
+          type: string
+          example: Wizard
+
+    ClassSpellcasting:
+      type: object
+      required:
+        - ability
+      properties:
+        ability:
+          $ref: '#/components/schemas/AttributeShortname'
+        usesSpellbook:
+          type: boolean
+          example: true
+        canCastRituals:
+          type: boolean
+          example: true
+
+    ClassFeatureItem:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          example: Spellcasting
+        description:
+          type: string
+          example: You can prepare and cast wizard spells.
+
+    ClassLevelProgressionItem:
+      type: object
+      required:
+        - level
+        - features
+      properties:
+        level:
+          type: integer
+          example: 1
+        features:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassFeatureItem'
+
+    ClassDetail:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+        - primaryattributes
+        - recommendedskills
+        - savingthrows
+        - hitdie
+        - role
+        - description
+        - spellcasting
+        - subclasses
+        - levelprogression
+      properties:
+        id:
+          type: integer
+          example: 12
+        name:
+          type: string
+          example: Wizard
+        slug:
+          type: string
+          example: wizard
+        primaryattributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributeShortname'
+          example:
+            - INT
+        recommendedskills:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillName'
+          example:
+            - Arcana
+            - Investigation
+            - History
+            - Nature
+            - Religion
+        savingthrows:
+          type: array
+          items:
+            $ref: '#/components/schemas/AttributeShortname'
+          example:
+            - INT
+            - WIS
+        hitdie:
+          type: integer
+          example: 6
+        role:
+          $ref: '#/components/schemas/ClassRole'
+        description:
+          type: string
+          example: A learned arcane scholar who studies the inner workings of magic to prepare spells, master rituals, and wield unmatched magical versatility.
+        spellcasting:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/ClassSpellcasting'
+        subclasses:
+          type: array
+          items:
+            type: string
+          example:
+            - Evoker
+        levelprogression:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClassLevelProgressionItem'
+
+    SpellListItem:
+      type: object
+      required:
+        - id
+        - name
+        - level
+        - levelLabel
+      properties:
+        id:
+          type: integer
           example: 1
         name:
           type: string
-          example: Fighter
+          example: Acid Splash
+        level:
+          type: integer
+          example: 0
+        levelLabel:
+          type: string
+          example: Cantrip
+
+    SpellComponents:
+      type: object
+      required:
+        - verbal
+        - somatic
+        - material
+        - materialDescription
+      properties:
+        verbal:
+          type: boolean
+          example: true
+        somatic:
+          type: boolean
+          example: true
+        material:
+          type: boolean
+          example: false
+        materialDescription:
+          type: string
+          nullable: true
+          example: null
+
+    SpellScalingEntry:
+      type: object
+      required:
+        - level
+        - description
+      properties:
+        level:
+          type: integer
+          example: 5
+        description:
+          type: string
+          example: damage increases to 2d6
+
+    SpellScaling:
+      type: object
+      required:
+        - entries
+      properties:
+        entries:
+          type: array
+          items:
+            $ref: '#/components/schemas/SpellScalingEntry'
+
+    SpellDetail:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+        - source
+        - school
+        - level
+        - levelLabel
+        - castingTime
+        - range
+        - components
+        - duration
+        - description
+        - classes
+        - scaling
+      properties:
+        id:
+          type: integer
+          example: 18
+        name:
+          type: string
+          example: Alarm
+        slug:
+          type: string
+          example: alarm
+        source:
+          type: string
+          example: Player's Handbook
+        school:
+          type: string
+          example: Abjuration
+        level:
+          type: integer
+          example: 1
+        levelLabel:
+          type: string
+          example: Level 1
+        castingTime:
+          type: string
+          example: 1 minute or Ritual
+        range:
+          type: string
+          example: 30 feet
+        components:
+          $ref: '#/components/schemas/SpellComponents'
+        duration:
+          type: string
+          example: 8 hours
+        description:
+          type: string
+          example: You set an alarm against intrusion.
+        classes:
+          type: array
+          items:
+            type: string
+          example:
+            - Ranger
+            - Wizard
+        scaling:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/SpellScaling'
 
     ErrorResponse:
       type: object

--- a/tests/clients/spells.client.ts
+++ b/tests/clients/spells.client.ts
@@ -1,0 +1,13 @@
+import { APIRequestContext, APIResponse } from '@playwright/test';
+
+export class SpellsClient {
+  constructor(private readonly request: APIRequestContext) {}
+
+  async getSpells(): Promise<APIResponse> {
+    return this.request.get('/api/spells');
+  }
+
+  async getSpellDetail(identifier: string | number): Promise<APIResponse> {
+    return this.request.get(`/api/spells/${identifier}`);
+  }
+}

--- a/tests/data/spells.expected.ts
+++ b/tests/data/spells.expected.ts
@@ -1,0 +1,106 @@
+import { SpellDetail, SpellListItem } from '@/app/types/spell';
+
+export const expectedSpellsList: SpellListItem[] = [
+  {
+    id: 1,
+    name: 'Acid Splash',
+    level: 0,
+    levelLabel: 'Cantrip',
+  },
+  {
+    id: 18,
+    name: 'Alarm',
+    level: 1,
+    levelLabel: 'Level 1',
+  },
+  {
+    id: 20,
+    name: 'Animal Friendship',
+    level: 1,
+    levelLabel: 'Level 1',
+  },
+];
+
+export const expectedDetailedSpells: Record<string, SpellDetail> = {
+  'acid-splash': {
+    id: 1,
+    name: 'Acid Splash',
+    slug: 'acid-splash',
+    source: "Player's Handbook",
+    school: 'Evocation',
+    level: 0,
+    levelLabel: 'Cantrip',
+    castingTime: 'Action',
+    range: '60 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: false,
+      materialDescription: null,
+    },
+    duration: 'Instantaneous',
+    description:
+      'You create an acidic bubble at a point within range, where it explodes in a 5-foot-radius Sphere. Each creature in that Sphere must succeed on a Dexterity saving throw or take 1d6 Acid damage.',
+    classes: ['Sorcerer', 'Wizard'],
+    scaling: {
+      entries: [
+        {
+          level: 5,
+          description: 'damage increases to 2d6',
+        },
+        {
+          level: 11,
+          description: 'damage increases to 3d6',
+        },
+        {
+          level: 17,
+          description: 'damage increases to 4d6',
+        },
+      ],
+    },
+  },
+  alarm: {
+    id: 18,
+    name: 'Alarm',
+    slug: 'alarm',
+    source: "Player's Handbook",
+    school: 'Abjuration',
+    level: 1,
+    levelLabel: 'Level 1',
+    castingTime: '1 minute or Ritual',
+    range: '30 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: true,
+      materialDescription: 'a bell and silver wire',
+    },
+    duration: '8 hours',
+    description:
+      'You set an alarm against intrusion. Choose a door, a window, or an area within range that is no larger than a 20-foot Cube. Until the spell ends, an alarm alerts you whenever a creature touches or enters the warded area. When you cast the spell, you can designate creatures that won’t set off the alarm. You also choose whether the alarm is audible or mental:\n\nAudible Alarm. The alarm produces the sound of a handbell for 10 seconds within 60 feet of the warded area.\n\nMental Alarm. You are alerted by a mental ping if you are within 1 mile of the warded area. This ping awakens you if you’re asleep.',
+    classes: ['Ranger', 'Wizard'],
+    scaling: null,
+  },
+  'animal-friendship': {
+    id: 20,
+    name: 'Animal Friendship',
+    slug: 'animal-friendship',
+    source: "Player's Handbook",
+    school: 'Enchantment',
+    level: 1,
+    levelLabel: 'Level 1',
+    castingTime: 'Action',
+    range: '30 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: true,
+      materialDescription: 'a morsel of food',
+    },
+    duration: '24 hours',
+    description:
+      'Target a Beast that you can see within range. The target must succeed on a Wisdom saving throw or have the Charmed condition for the duration. If you or one of your allies deals damage to the target, the spell ends.\n\nUsing a Higher-Level Spell Slot. You can target one additional Beast for each spell slot level above 1.',
+    classes: ['Bard', 'Druid', 'Ranger'],
+    scaling: null,
+  },
+};

--- a/tests/features/spells.spec.ts
+++ b/tests/features/spells.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test';
+
+import { SpellListItem, SpellDetail } from '@/app/types/spell';
+import { SpellsClient } from '../clients/spells.client';
+import { expectedDetailedSpells, expectedSpellsList } from '../data/spells.expected';
+import { SpellAssert } from '../helpers/spells.assertions';
+
+test.describe('Spells API - List', { tag: ['@spells', '@list'] }, () => {
+  test('Validate Schema', { tag: ['@schema'] }, async ({ request }) => {
+    const spellsClient = new SpellsClient(request);
+    const spellAssert = new SpellAssert();
+
+    const response = await spellsClient.getSpells();
+
+    await spellAssert.success(response);
+
+    const body: SpellListItem[] = await response.json();
+
+    await spellAssert.validateSchema(body);
+  });
+
+  for (const expectedSpell of expectedSpellsList) {
+    test(
+      `Validate Spell ${expectedSpell.name}`,
+      { tag: ['@data'] },
+      async ({ request }) => {
+        const spellsClient = new SpellsClient(request);
+        const spellAssert = new SpellAssert();
+
+        const response = await spellsClient.getSpells();
+
+        await spellAssert.success(response);
+
+        const body: SpellListItem[] = await response.json();
+
+        await spellAssert.validateSpellInList(body, expectedSpell);
+      },
+    );
+  }
+});
+
+test.describe('Spells API - Detail', { tag: ['@spells', '@detail'] }, () => {
+  test('Validate Schema', { tag: ['@schema'] }, async ({ request }) => {
+    const spellsClient = new SpellsClient(request);
+    const spellAssert = new SpellAssert();
+
+    const firstExpectedSpell = Object.values(expectedDetailedSpells)[0];
+    const response = await spellsClient.getSpellDetail(firstExpectedSpell.id);
+
+    await spellAssert.success(response);
+
+    const body: SpellDetail = await response.json();
+
+    await spellAssert.validateDetailSchema(body);
+  });
+
+  for (const [identifier, expectedSpell] of Object.entries(
+    expectedDetailedSpells,
+  )) {
+    test(
+      `Validate Spell Detail by id - ${expectedSpell.name}`,
+      { tag: ['@data'] },
+      async ({ request }) => {
+        const spellsClient = new SpellsClient(request);
+        const spellAssert = new SpellAssert();
+
+        const response = await spellsClient.getSpellDetail(expectedSpell.id);
+
+        await spellAssert.success(response);
+
+        const body: SpellDetail = await response.json();
+
+        await spellAssert.validateSpellDetail(body, expectedSpell);
+      },
+    );
+
+    test(
+      `Validate Spell Detail by identifier - ${expectedSpell.name}`,
+      { tag: ['@data'] },
+      async ({ request }) => {
+        const spellsClient = new SpellsClient(request);
+        const spellAssert = new SpellAssert();
+
+        const response = await spellsClient.getSpellDetail(identifier);
+
+        await spellAssert.success(response);
+
+        const body: SpellDetail = await response.json();
+
+        await spellAssert.validateSpellDetail(body, expectedSpell);
+      },
+    );
+  }
+
+  test(
+    'Validate detailed spells are present in list with matching base fields',
+    { tag: ['@consistency', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells();
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      for (const expectedSpell of Object.values(expectedDetailedSpells)) {
+        await spellAssert.validateSpellInList(body, {
+          id: expectedSpell.id,
+          name: expectedSpell.name,
+          level: expectedSpell.level,
+          levelLabel: expectedSpell.levelLabel,
+        });
+      }
+    },
+  );
+
+  for (const [identifier, expectedSpell] of Object.entries(
+    expectedDetailedSpells,
+  )) {
+    test(
+      `Validate Spell Detail consistency by id and identifier - ${expectedSpell.name}`,
+      { tag: ['@consistency', '@data'] },
+      async ({ request }) => {
+        const spellsClient = new SpellsClient(request);
+        const spellAssert = new SpellAssert();
+
+        const responseById = await spellsClient.getSpellDetail(expectedSpell.id);
+        const responseByIdentifier = await spellsClient.getSpellDetail(identifier);
+
+        await spellAssert.success(responseById);
+        await spellAssert.success(responseByIdentifier);
+
+        const bodyById: SpellDetail = await responseById.json();
+        const bodyByIdentifier: SpellDetail = await responseByIdentifier.json();
+
+        await spellAssert.validateSpellDetail(bodyById, expectedSpell);
+        await spellAssert.validateSpellDetail(bodyByIdentifier, expectedSpell);
+
+        await test.step(
+          'Validate payload consistency between id and identifier',
+          async () => {
+          expect(bodyById).toEqual(bodyByIdentifier);
+          },
+        );
+      },
+    );
+  }
+
+  test(
+    'Validate Spell Detail by invalid id',
+    { tag: ['@negative', '@error'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpellDetail(9999);
+
+      await spellAssert.notFound(response);
+
+      const body: { error: string } = await response.json();
+
+      await spellAssert.validateErrorResponse(body, 'Spell not found');
+    },
+  );
+
+  test(
+    'Validate Spell Detail by invalid identifier',
+    { tag: ['@negative', '@error'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpellDetail('unknown-spell');
+
+      await spellAssert.notFound(response);
+
+      const body: { error: string } = await response.json();
+
+      await spellAssert.validateErrorResponse(body, 'Spell not found');
+    },
+  );
+});

--- a/tests/helpers/spells.assertions.ts
+++ b/tests/helpers/spells.assertions.ts
@@ -1,0 +1,148 @@
+import { SpellDetail, SpellListItem } from '@/app/types/spell';
+import { test, expect } from '@playwright/test';
+
+export class SpellAssert {
+  async success(response: { status(): number; ok(): boolean }) {
+    await test.step('Should return status code 200', async () => {
+      expect(response.status()).toBe(200);
+      expect(response.ok()).toBeTruthy();
+    });
+  }
+
+  async notFound(response: { status(): number; ok(): boolean }) {
+    await test.step('Should return status code 404', async () => {
+      expect(response.status()).toBe(404);
+      expect(response.ok()).toBeFalsy();
+    });
+  }
+
+  async validateSchema(spellList: SpellListItem[]) {
+    await test.step('Should validate spells list is not empty', async () => {
+      expect(spellList).toBeTruthy();
+      expect(Array.isArray(spellList)).toBe(true);
+      expect(spellList.length).toBeGreaterThan(0);
+    });
+
+    for (const spell of spellList) {
+      await test.step(`Validate schema for ${spell.name}`, async () => {
+        expect(spell).toHaveProperty('id');
+        expect(spell).toHaveProperty('name');
+        expect(spell).toHaveProperty('level');
+        expect(spell).toHaveProperty('levelLabel');
+
+        expect(typeof spell.id).toBe('number');
+        expect(typeof spell.name).toBe('string');
+        expect(typeof spell.level).toBe('number');
+        expect(typeof spell.levelLabel).toBe('string');
+      });
+    }
+  }
+
+  async validateDetailSchema(spell: SpellDetail) {
+    await test.step(`Validate detail schema for ${spell.name}`, async () => {
+      expect(spell).toHaveProperty('id');
+      expect(spell).toHaveProperty('name');
+      expect(spell).toHaveProperty('slug');
+      expect(spell).toHaveProperty('source');
+      expect(spell).toHaveProperty('school');
+      expect(spell).toHaveProperty('level');
+      expect(spell).toHaveProperty('levelLabel');
+      expect(spell).toHaveProperty('castingTime');
+      expect(spell).toHaveProperty('range');
+      expect(spell).toHaveProperty('components');
+      expect(spell).toHaveProperty('duration');
+      expect(spell).toHaveProperty('description');
+      expect(spell).toHaveProperty('classes');
+      expect(spell).toHaveProperty('scaling');
+
+      expect(typeof spell.id).toBe('number');
+      expect(typeof spell.name).toBe('string');
+      expect(typeof spell.slug).toBe('string');
+      expect(typeof spell.source).toBe('string');
+      expect(typeof spell.school).toBe('string');
+      expect(typeof spell.level).toBe('number');
+      expect(typeof spell.levelLabel).toBe('string');
+      expect(typeof spell.castingTime).toBe('string');
+      expect(typeof spell.range).toBe('string');
+      expect(typeof spell.duration).toBe('string');
+      expect(typeof spell.description).toBe('string');
+      expect(Array.isArray(spell.classes)).toBe(true);
+      expect(
+        spell.scaling === null || typeof spell.scaling === 'object',
+      ).toBe(true);
+    });
+
+    await test.step('Validate components schema', async () => {
+      expect(spell.components).toHaveProperty('verbal');
+      expect(spell.components).toHaveProperty('somatic');
+      expect(spell.components).toHaveProperty('material');
+      expect(spell.components).toHaveProperty('materialDescription');
+
+      expect(typeof spell.components.verbal).toBe('boolean');
+      expect(typeof spell.components.somatic).toBe('boolean');
+      expect(typeof spell.components.material).toBe('boolean');
+      expect(
+        spell.components.materialDescription === null ||
+          typeof spell.components.materialDescription === 'string',
+      ).toBe(true);
+    });
+
+    for (const className of spell.classes) {
+      await test.step(`Validate class schema for ${className}`, async () => {
+        expect(typeof className).toBe('string');
+      });
+    }
+
+    if (spell.scaling) {
+      for (const entry of spell.scaling.entries) {
+        await test.step(
+          `Validate scaling schema for level ${entry.level}`,
+          async () => {
+            expect(typeof entry.level).toBe('number');
+            expect(typeof entry.description).toBe('string');
+          },
+        );
+      }
+    }
+  }
+
+  findSpellById(spellList: SpellListItem[], expectedId: number): SpellListItem {
+    const spell = spellList.find((item) => item.id === expectedId);
+
+    if (!spell) {
+      throw new Error(`Spell with id ${expectedId} not found`);
+    }
+
+    return spell;
+  }
+
+  async validateSpellInList(
+    spellList: SpellListItem[],
+    expectedSpell: SpellListItem,
+  ) {
+    const spell = this.findSpellById(spellList, expectedSpell.id);
+
+    await test.step('Validate spell list item', async () => {
+      expect(spell).toEqual(expectedSpell);
+    });
+  }
+
+  async validateSpellDetail(actualSpell: SpellDetail, expectedSpell: SpellDetail) {
+    await this.validateDetailSchema(actualSpell);
+
+    await test.step('Validate spell detail', async () => {
+      expect(actualSpell).toEqual(expectedSpell);
+    });
+  }
+
+  async validateErrorResponse(
+    errorResponse: { error: string },
+    expectedError: string,
+  ) {
+    await test.step('Validate error response schema', async () => {
+      expect(errorResponse).toHaveProperty('error');
+      expect(typeof errorResponse.error).toBe('string');
+      expect(errorResponse.error).toBe(expectedError);
+    });
+  }
+}


### PR DESCRIPTION
- add new spell records and related insert data
- add spell classes and spell scaling data
- extend spells API coverage with new detailed fixtures
- validate two new spells in list and detail scenarios
- add consistency coverage between spells list and detail endpoints
- keep test structure aligned with existing API test conventions