### PR TITLE
feat: add character skill proficiencies and skills endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Request body fields:
 - `backgroundId` optional
 - `level` optional, defaults to `1`
 - `abilityScores` optional
+- `skillProficiencies` optional
 
 Response fields:
 
@@ -288,6 +289,7 @@ Response fields:
 - `missingFields`
 - `abilityScores`
 - `abilityModifiers`
+- `skillProficiencies`
 - `abilityScoreRules`
 - `classDetails`
 - `speciesDetails`
@@ -322,6 +324,7 @@ Response fields:
 - `backgroundId`
 - `level`
 - `missingFields`
+- `skillProficiencies`
 - `abilityScores`
 - `abilityModifiers`
 - `abilityScoreRules`
@@ -349,6 +352,7 @@ Accepted fields:
 - `backgroundId`
 - `level`
 - `abilityScores`
+- `skillProficiencies`
 
 Returns:
 
@@ -357,6 +361,29 @@ Returns:
 - `401` with `{ "error": "Unauthorized" }`
 - `404` with `{ "error": "Character not found" }`
 - `500` with `{ "error": "Failed to update character" }`
+
+### `GET /api/characters/{id}/skills`
+
+Returns the calculated skill list for the character.
+
+Requires bearer token.
+
+Each item includes:
+
+- `name`
+- `ability`
+- `isProficient`
+- `abilityModifier`
+- `proficiencyBonus`
+- `total`
+
+This is a derived view, not a raw persisted payload. The values are derived from the character's current `skillProficiencies`, level, and resolved ability scores. When the character has no saved ability scores yet, ability-based values are currently calculated as `0`.
+
+Returns:
+
+- `401` with `{ "error": "Unauthorized" }`
+- `404` with `{ "error": "Character not found" }`
+- `500` with `{ "error": "Failed to fetch character skills" }`
 
 ### `GET /api/characters/{id}/ability-score-options`
 
@@ -494,6 +521,7 @@ Character detail:
   "backgroundId": 13,
   "level": 1,
   "missingFields": [],
+  "skillProficiencies": ["Arcana", "History"],
   "abilityScores": {
     "base": {
       "STR": 8,
@@ -611,6 +639,29 @@ Character detail:
     ]
   }
 }
+```
+
+Character skills:
+
+```json
+[
+  {
+    "name": "Arcana",
+    "ability": "INT",
+    "isProficient": true,
+    "abilityModifier": 3,
+    "proficiencyBonus": 2,
+    "total": 5
+  },
+  {
+    "name": "Stealth",
+    "ability": "DEX",
+    "isProficient": false,
+    "abilityModifier": 2,
+    "proficiencyBonus": 0,
+    "total": 2
+  }
+]
 ```
 
 Character ability score options:

--- a/app/api/characters/[id]/route.ts
+++ b/app/api/characters/[id]/route.ts
@@ -3,6 +3,9 @@ import {
   formatCharacterResponse,
   isCharacterAbilityScoresOrNull,
   isNullablePositiveInteger,
+  isSkillProficiencies,
+  serializeCharacterAbilityScoresInput,
+  serializeSkillProficiencies,
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
 import { CharacterUpdateRequestBody } from '@/app/types/character';
@@ -27,7 +30,9 @@ function isCharacterUpdateRequestBody(
       isNullablePositiveInteger(value.backgroundId)) &&
     (!('level' in value) || isNullablePositiveInteger(value.level)) &&
     (!('abilityScores' in value) ||
-      isCharacterAbilityScoresOrNull(value.abilityScores))
+      isCharacterAbilityScoresOrNull(value.abilityScores)) &&
+    (!('skillProficiencies' in value) ||
+      isSkillProficiencies(value.skillProficiencies))
   );
 }
 
@@ -48,7 +53,7 @@ export async function GET(request: Request, { params }: RouteContext) {
 
   try {
     const characterRows = await sql`
-      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores
+      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
       FROM characters
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
@@ -71,6 +76,7 @@ export async function GET(request: Request, { params }: RouteContext) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      skillProficiencies: character.skillproficiencies,
     });
 
     return NextResponse.json(responseBody, { status: 200 });
@@ -109,7 +115,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
 
     const sql = getSql();
     const existingRows = await sql`
-      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores
+      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
       FROM characters
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
@@ -148,8 +154,14 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       body.level !== undefined ? body.level : Number(existingCharacter.level);
     const nextAbilityScores =
       body.abilityScores !== undefined
-        ? body.abilityScores
+        ? body.abilityScores === null
+          ? null
+          : serializeCharacterAbilityScoresInput(body.abilityScores)
         : existingCharacter.abilityscores;
+    const nextSkillProficiencies =
+      body.skillProficiencies !== undefined
+        ? serializeSkillProficiencies(body.skillProficiencies)
+        : serializeSkillProficiencies(existingCharacter.skillproficiencies ?? []);
     const nextStatus =
       nextClassId !== null &&
       nextSpeciesId !== null &&
@@ -167,10 +179,11 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         backgroundid = ${nextBackgroundId},
         level = ${nextLevel},
         abilityscores = ${nextAbilityScores},
+        skillproficiencies = ${nextSkillProficiencies}::jsonb,
         updatedat = NOW()
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
-      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores
+      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
     `;
 
     const character = characterRows[0];
@@ -182,6 +195,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      skillProficiencies: character.skillproficiencies,
     });
 
     return NextResponse.json(responseBody, { status: 200 });

--- a/app/api/characters/[id]/skills/route.ts
+++ b/app/api/characters/[id]/skills/route.ts
@@ -1,0 +1,46 @@
+import { getAuthenticatedOwnerFromRequest } from '@/app/lib/auth';
+import { getCharacterSkills } from '@/app/lib/character-skills';
+import { NextResponse } from 'next/server';
+
+interface RouteContext {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export async function GET(request: Request, { params }: RouteContext) {
+  const { id } = await params;
+  const parsedId = Number(id);
+  const authenticatedOwner = getAuthenticatedOwnerFromRequest(request);
+
+  if (!authenticatedOwner) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (!Number.isInteger(parsedId) || parsedId <= 0) {
+    return NextResponse.json({ error: 'Character not found' }, { status: 404 });
+  }
+
+  try {
+    const characterSkills = await getCharacterSkills(
+      authenticatedOwner.id,
+      parsedId,
+    );
+
+    if (!characterSkills) {
+      return NextResponse.json(
+        { error: 'Character not found' },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(characterSkills, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch character skills:', error);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch character skills' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/characters/route.ts
+++ b/app/api/characters/route.ts
@@ -5,6 +5,9 @@ import {
   getCharacterStatus,
   isCharacterAbilityScoresOrNull,
   isNullablePositiveInteger,
+  isSkillProficiencies,
+  serializeCharacterAbilityScoresInput,
+  serializeSkillProficiencies,
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
 import {
@@ -31,7 +34,9 @@ function isCharacterCreateRequestBody(
       isNullablePositiveInteger(value.backgroundId)) &&
     (!('level' in value) || isNullablePositiveInteger(value.level)) &&
     (!('abilityScores' in value) ||
-      isCharacterAbilityScoresOrNull(value.abilityScores))
+      isCharacterAbilityScoresOrNull(value.abilityScores)) &&
+    (!('skillProficiencies' in value) ||
+      isSkillProficiencies(value.skillProficiencies))
   );
 }
 
@@ -132,7 +137,13 @@ export async function POST(request: Request) {
     const speciesId = body.speciesId ?? null;
     const backgroundId = body.backgroundId ?? null;
     const level = body.level ?? 1;
-    const abilityScores = body.abilityScores ?? null;
+    const abilityScores =
+      body.abilityScores === undefined || body.abilityScores === null
+        ? null
+        : serializeCharacterAbilityScoresInput(body.abilityScores);
+    const skillProficiencies = serializeSkillProficiencies(
+      body.skillProficiencies ?? [],
+    );
     const status =
       classId !== null && speciesId !== null && backgroundId !== null
         ? 'complete'
@@ -148,7 +159,8 @@ export async function POST(request: Request) {
         speciesid,
         backgroundid,
         level,
-        abilityscores
+        abilityscores,
+        skillproficiencies
       )
       VALUES (
         ${authenticatedOwner.id},
@@ -158,9 +170,10 @@ export async function POST(request: Request) {
         ${speciesId},
         ${backgroundId},
         ${level},
-        ${abilityScores}
+        ${abilityScores},
+        ${skillProficiencies}::jsonb
       )
-      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores
+      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
     `;
 
     const character = characterRows[0];
@@ -172,6 +185,7 @@ export async function POST(request: Request) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      skillProficiencies: character.skillproficiencies,
     });
 
     return NextResponse.json(responseBody, { status: 201 });

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -4,6 +4,7 @@ export type ApiResource = {
   description: string;
   summary: string;
   listFields: string[];
+  previewFields?: string[];
   endpoints: string[];
 };
 
@@ -87,9 +88,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, ability score selection, spell selection, and enriched responses that include class, species, background, and derived ability modifier details.',
+      'Protected character management flow with creation, updates, ability score selection, character skill calculation, spell selection, and enriched responses that include class, species, background, derived ability modifier details, and selected skill proficiencies.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, ability score progression, and derived modifier data.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, ability score progression, derived modifier data, and calculated skill totals.',
     listFields: [
       'id',
       'name',
@@ -101,9 +102,17 @@ export const apiResources: ApiResource[] = [
       'missingFields',
       'abilityScores',
       'abilityModifiers',
+      'skillProficiencies',
       'abilityScoreRules',
       'classDetails',
       'speciesDetails',
+      'backgroundDetails',
+    ],
+    previewFields: [
+      'status',
+      'abilityScores',
+      'abilityModifiers',
+      'skillProficiencies',
       'backgroundDetails',
     ],
     endpoints: [
@@ -113,6 +122,7 @@ export const apiResources: ApiResource[] = [
       'PATCH /api/characters/{id}',
       'GET /api/characters/{id}/ability-score-options',
       'PUT /api/characters/{id}/ability-scores',
+      'GET /api/characters/{id}/skills',
       'GET /api/characters/{id}/spell-options',
       'GET /api/characters/{id}/spell-selection',
       'PUT /api/characters/{id}/spells',
@@ -123,5 +133,5 @@ export const apiResources: ApiResource[] = [
 export const projectHighlights = [
   'Visual entrypoint for the API project',
   'Interactive documentation available in /docs',
-  'Character flows now cover class, species, background, ability scores, and derived modifiers',
+  'Character flows now expose calculated skills, derived modifiers, and richer detail payloads',
 ];

--- a/app/lib/character-skills.ts
+++ b/app/lib/character-skills.ts
@@ -1,0 +1,59 @@
+import { getCharacterAbilityModifiers, getProficiencyBonus, parseSkillProficiencies } from '@/app/lib/characters';
+import { getSql } from './db';
+import { CharacterSkillItem } from '@/app/types/character';
+import { Attributeshortname } from '@/app/types/attribute';
+import { SkillName } from '@/app/types/skill';
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+export async function getCharacterSkills(
+  ownerId: number,
+  characterId: number,
+): Promise<CharacterSkillItem[] | null> {
+  const sql = getSql();
+  const characterRows = await sql`
+    SELECT id, level, abilityscores, skillproficiencies
+    FROM characters
+    WHERE id = ${characterId}
+      AND ownerid = ${ownerId}
+    LIMIT 1
+  `;
+
+  if (!characterRows || characterRows.length === 0) {
+    return null;
+  }
+
+  const character = characterRows[0];
+  const level = toNumber(character.level);
+  const proficiencyBonus = getProficiencyBonus(level);
+  const abilityModifiers = getCharacterAbilityModifiers(
+    character.abilityscores,
+  );
+  const skillProficiencies = new Set<SkillName>(
+    parseSkillProficiencies(character.skillproficiencies),
+  );
+
+  const skillRows = await sql`
+    SELECT name, attribute
+    FROM skills
+    ORDER BY id
+  `;
+
+  return skillRows.map((skill) => {
+    const isProficient = skillProficiencies.has(skill.name);
+    const ability = skill.attribute as Attributeshortname;
+    const abilityModifier = abilityModifiers?.[ability] ?? 0;
+    const appliedProficiencyBonus = isProficient ? proficiencyBonus : 0;
+
+    return {
+      name: skill.name,
+      ability,
+      isProficient,
+      abilityModifier,
+      proficiencyBonus: appliedProficiencyBonus,
+      total: abilityModifier + appliedProficiencyBonus,
+    };
+  });
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -15,6 +15,7 @@ import {
 import { Attributeshortname } from '@/app/types/attribute';
 import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
+import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getSql } from './db';
 
 function toNumber(value: number | string): number {
@@ -209,21 +210,73 @@ function getAbilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
 
-function getCharacterAbilityModifiers(
-  abilityScores: CharacterResolvedAbilityScores | null,
+export function getCharacterAbilityModifiers(
+  abilityScores: CharacterResolvedAbilityScores | CharacterAbilityScoresInput | CharacterAbilityScores | string | null,
 ): CharacterAbilityModifiers | null {
-  if (!abilityScores) {
+  const resolvedAbilityScores = parseCharacterAbilityScores(abilityScores);
+
+  if (!resolvedAbilityScores) {
     return null;
   }
 
   return {
-    STR: getAbilityModifier(abilityScores.final.STR),
-    DEX: getAbilityModifier(abilityScores.final.DEX),
-    CON: getAbilityModifier(abilityScores.final.CON),
-    INT: getAbilityModifier(abilityScores.final.INT),
-    WIS: getAbilityModifier(abilityScores.final.WIS),
-    CHA: getAbilityModifier(abilityScores.final.CHA),
+    STR: getAbilityModifier(resolvedAbilityScores.final.STR),
+    DEX: getAbilityModifier(resolvedAbilityScores.final.DEX),
+    CON: getAbilityModifier(resolvedAbilityScores.final.CON),
+    INT: getAbilityModifier(resolvedAbilityScores.final.INT),
+    WIS: getAbilityModifier(resolvedAbilityScores.final.WIS),
+    CHA: getAbilityModifier(resolvedAbilityScores.final.CHA),
   };
+}
+
+function isSkillName(value: unknown): value is SkillName {
+  return typeof value === 'string' && SKILL_NAMES.includes(value as SkillName);
+}
+
+export function isSkillProficiencies(value: unknown): value is SkillName[] {
+  return Array.isArray(value) && value.every(isSkillName);
+}
+
+export function parseSkillProficiencies(value: unknown): SkillName[] {
+  if (isSkillProficiencies(value)) {
+    return [...new Set(value)];
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+
+      return isSkillProficiencies(parsed) ? [...new Set(parsed)] : [];
+    } catch {
+      return [];
+    }
+  }
+
+  return [];
+}
+
+export function serializeSkillProficiencies(value: SkillName[]): string {
+  return JSON.stringify([...new Set(value)]);
+}
+
+export function getProficiencyBonus(level: number): number {
+  if (level >= 17) {
+    return 6;
+  }
+
+  if (level >= 13) {
+    return 5;
+  }
+
+  if (level >= 9) {
+    return 4;
+  }
+
+  if (level >= 5) {
+    return 3;
+  }
+
+  return 2;
 }
 
 function normalizeAbilityScores(
@@ -440,7 +493,13 @@ export async function formatCharacterResponse(character: {
   speciesId: number | string | null;
   backgroundId: number | string | null;
   level: number | string;
-  abilityScores?: CharacterAbilityScores | string | null;
+  abilityScores?:
+    | CharacterAbilityScores
+    | CharacterAbilityScoresInput
+    | CharacterResolvedAbilityScores
+    | string
+    | null;
+  skillProficiencies?: SkillName[] | string | null;
 }): Promise<CharacterResponseBody> {
   const formattedCharacter = {
     id: toNumber(character.id),
@@ -454,6 +513,9 @@ export async function formatCharacterResponse(character: {
     level: toNumber(character.level),
     abilityScores: parseCharacterAbilityScores(
       character.abilityScores ?? null,
+    ),
+    skillProficiencies: parseSkillProficiencies(
+      character.skillProficiencies ?? [],
     ),
   };
 
@@ -484,6 +546,7 @@ export async function formatCharacterResponse(character: {
     missingFields,
     abilityScores: formattedCharacter.abilityScores,
     abilityModifiers,
+    skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,
     classDetails,
     speciesDetails,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -85,8 +85,15 @@ export default function HomePage() {
               <p>{resource.summary}</p>
               <p className="resource-description">{resource.description}</p>
               <p className="resource-fields">
-                Key fields: {resource.listFields.slice(0, 5).join(', ')}
-                {resource.listFields.length > 5 ? ', ...' : ''}
+                Key fields:{' '}
+                {(resource.previewFields ?? resource.listFields.slice(0, 5)).join(
+                  ', ',
+                )}
+                {resource.previewFields
+                  ? ''
+                  : resource.listFields.length > 5
+                    ? ', ...'
+                    : ''}
               </p>
 
               <div className="endpoint-stack">

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -1,4 +1,5 @@
 import { Attributeshortname } from './attribute';
+import { SkillName } from './skill';
 
 export type CharacterStatus = 'draft' | 'complete';
 
@@ -99,6 +100,7 @@ export interface CharacterCreateRequestBody {
   backgroundId?: number | null;
   level?: number | null;
   abilityScores?: CharacterAbilityScoresInput | null;
+  skillProficiencies?: SkillName[];
 }
 
 export interface CharacterUpdateRequestBody {
@@ -108,6 +110,7 @@ export interface CharacterUpdateRequestBody {
   backgroundId?: number | null;
   level?: number | null;
   abilityScores?: CharacterAbilityScoresInput | null;
+  skillProficiencies?: SkillName[];
 }
 
 export interface CharacterListItem {
@@ -128,6 +131,7 @@ export interface CharacterResponseBody {
   missingFields: CharacterMissingField[];
   abilityScores: CharacterResolvedAbilityScores | null;
   abilityModifiers: CharacterAbilityModifiers | null;
+  skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;
   classDetails?: CharacterClassDetails | null;
   speciesDetails?: import('./species').SpeciesDetail | null;
@@ -186,4 +190,13 @@ export interface CharacterAbilityScoreOptionsResponseBody {
 
 export interface CharacterAbilityScoresUpdateRequestBody {
   abilityScores: CharacterAbilityScoresInput;
+}
+
+export interface CharacterSkillItem {
+  name: SkillName;
+  ability: Attributeshortname;
+  isProficient: boolean;
+  abilityModifier: number;
+  proficiencyBonus: number;
+  total: number;
 }

--- a/app/types/skill.ts
+++ b/app/types/skill.ts
@@ -1,24 +1,27 @@
 import { Attributeshortname } from './attribute';
 
-export type SkillName =
-  | 'Athletics'
-  | 'Acrobatics'
-  | 'Sleight of Hand'
-  | 'Stealth'
-  | 'Arcana'
-  | 'History'
-  | 'Investigation'
-  | 'Nature'
-  | 'Religion'
-  | 'Animal Handling'
-  | 'Insight'
-  | 'Medicine'
-  | 'Perception'
-  | 'Survival'
-  | 'Deception'
-  | 'Intimidation'
-  | 'Performance'
-  | 'Persuasion';
+export const SKILL_NAMES = [
+  'Athletics',
+  'Acrobatics',
+  'Sleight of Hand',
+  'Stealth',
+  'Arcana',
+  'History',
+  'Investigation',
+  'Nature',
+  'Religion',
+  'Animal Handling',
+  'Insight',
+  'Medicine',
+  'Perception',
+  'Survival',
+  'Deception',
+  'Intimidation',
+  'Performance',
+  'Persuasion',
+] as const;
+
+export type SkillName = (typeof SKILL_NAMES)[number];
 
 export interface SkillListItem {
   id: number;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.6.0
+  version: 1.7.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -15,7 +15,7 @@ info:
     - Classes list and detail
     - Spells list and detail
     - Species list and detail
-    - Character management, ability score flows, and character spell flows
+    - Character management, ability score flows, character skill flows, and character spell flows
 
 servers:
   - url: http://localhost:3000
@@ -39,7 +39,7 @@ tags:
   - name: Species
     description: Species list and species detail endpoints.
   - name: Characters
-    description: Protected character management and character spell selection endpoints.
+    description: Protected character management plus derived ability, skill, and spell endpoints.
 
 x-tagGroups:
   - name: Access
@@ -887,6 +887,9 @@ paths:
                   classId: 12
                   speciesId: 3
                   backgroundId: 13
+                  skillProficiencies:
+                    - Arcana
+                    - History
                   abilityScores:
                     base:
                       STR: 8
@@ -923,6 +926,7 @@ paths:
                   - backgroundId
                 abilityScores: null
                 abilityModifiers: null
+                skillProficiencies: []
                 abilityScoreRules: null
                 classDetails: null
                 speciesDetails: null
@@ -964,6 +968,7 @@ paths:
         When related data exists, the detail payload can include nested:
         - `abilityScores`
         - `abilityModifiers`
+        - `skillProficiencies`
         - `abilityScoreRules`
         - `classDetails`
         - `speciesDetails`
@@ -988,6 +993,9 @@ paths:
                 backgroundId: 13
                 level: 1
                 missingFields: []
+                skillProficiencies:
+                  - Arcana
+                  - History
                 abilityScores:
                   base:
                     STR: 8
@@ -1129,7 +1137,7 @@ paths:
       operationId: updateCharacter
       summary: Update character
       description: |
-        Updates a single character owned by the authenticated owner and returns the same enriched detail shape, including `abilityScores`, `abilityScoreRules`, `classDetails`, `speciesDetails`, and `backgroundDetails` when those relations exist.
+        Updates a single character owned by the authenticated owner and returns the same enriched detail shape, including `abilityScores`, `abilityModifiers`, `skillProficiencies`, `abilityScoreRules`, `classDetails`, `speciesDetails`, and `backgroundDetails` when those relations exist.
       security:
         - bearerAuth: []
       parameters:
@@ -1168,6 +1176,12 @@ paths:
                       INT: 2
                       WIS: 1
                       CHA: 0
+              updateSkillProficiencies:
+                summary: Update character skill proficiencies
+                value:
+                  skillProficiencies:
+                    - Arcana
+                    - History
       responses:
         '200':
           description: Character updated successfully
@@ -1207,6 +1221,72 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: Failed to update character
+
+  /api/characters/{id}/skills:
+    get:
+      tags:
+        - Characters
+      operationId: getCharacterSkills
+      summary: Get calculated character skills
+      description: |
+        Returns the calculated skill list for the character based on:
+        - current `skillProficiencies`
+        - current level
+        - derived ability modifiers
+
+        This endpoint is a derived view, not a raw persisted payload.
+
+        When the character has no saved ability scores yet, ability-based values are currently returned as `0`.
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CharacterId'
+      responses:
+        '200':
+          description: Character skills returned successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CharacterSkillItem'
+              example:
+                - name: Arcana
+                  ability: INT
+                  isProficient: true
+                  abilityModifier: 3
+                  proficiencyBonus: 2
+                  total: 5
+                - name: Stealth
+                  ability: DEX
+                  isProficient: false
+                  abilityModifier: 2
+                  proficiencyBonus: 0
+                  total: 2
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Unauthorized
+        '404':
+          description: Character not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Character not found
+        '500':
+          description: Failed to fetch character skills
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch character skills
 
   /api/characters/{id}/ability-score-options:
     get:
@@ -2466,6 +2546,13 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityScoresInput'
+        skillProficiencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillName'
+          example:
+            - Arcana
+            - History
 
     CharacterUpdateRequestBody:
       type: object
@@ -2497,6 +2584,13 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityScoresInput'
+        skillProficiencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillName'
+          example:
+            - Arcana
+            - History
 
     CharacterClassFeatureItem:
       type: object
@@ -2611,6 +2705,7 @@ components:
         - missingFields
         - abilityScores
         - abilityModifiers
+        - skillProficiencies
         - abilityScoreRules
         - classDetails
         - speciesDetails
@@ -2654,6 +2749,13 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityModifiers'
+        skillProficiencies:
+          type: array
+          items:
+            $ref: '#/components/schemas/SkillName'
+          example:
+            - Arcana
+            - History
         abilityScoreRules:
           nullable: true
           allOf:
@@ -2691,6 +2793,33 @@ components:
         levelLabel:
           type: string
           example: Cantrip
+
+    CharacterSkillItem:
+      type: object
+      required:
+        - name
+        - ability
+        - isProficient
+        - abilityModifier
+        - proficiencyBonus
+        - total
+      properties:
+        name:
+          $ref: '#/components/schemas/SkillName'
+        ability:
+          $ref: '#/components/schemas/AttributeShortname'
+        isProficient:
+          type: boolean
+          example: true
+        abilityModifier:
+          type: integer
+          example: 3
+        proficiencyBonus:
+          type: integer
+          example: 2
+        total:
+          type: integer
+          example: 5
 
     CharacterAbilityScoreOptionsResponseBody:
       type: object

--- a/tests/clients/characters.client.ts
+++ b/tests/clients/characters.client.ts
@@ -59,6 +59,12 @@ export class CharactersClient {
     });
   }
 
+  async getCharacterSkills(id: number, token?: string): Promise<APIResponse> {
+    return this.request.get(`/api/characters/${id}/skills`, {
+      headers: this.buildAuthHeaders(token),
+    });
+  }
+
   async updateCharacter(
     id: number,
     payload: CharacterUpdateRequestBody,

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -3,11 +3,13 @@ import {
   CharacterAbilityScoreOptionsResponseBody,
   CharacterAbilityScoresInput,
   CharacterAbilityScores,
+  CharacterSkillItem,
   CharacterListItem,
   CharacterResponseBody,
   CharacterSpellOptionsResponseBody,
   CharacterSpellSelectionResponseBody,
 } from '@/app/types/character';
+import { SkillName } from '@/app/types/skill';
 import { APIRequestContext, expect, test } from '@playwright/test';
 
 import { AuthClient } from '../clients/auth.client';
@@ -106,6 +108,20 @@ const patchedDraftAbilityScoresInput: CharacterAbilityScoresInput = {
     CHA: 0,
   },
 };
+
+const barbarianSkillProficiencies: SkillName[] = [
+  'Athletics',
+  'Intimidation',
+  'Perception',
+  'Survival',
+];
+
+const wizardSkillProficiencies: SkillName[] = [
+  'Arcana',
+  'History',
+  'Investigation',
+  'Religion',
+];
 
 async function issueDemoToken(request: APIRequestContext) {
   const authClient = new AuthClient(request);
@@ -752,6 +768,98 @@ test.describe(
   );
 
   test(
+    'Add Skills Barbarian',
+    { tag: ['@patch', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.updateCharacter(
+        createdCharacterId,
+        {
+          skillProficiencies: barbarianSkillProficiencies,
+        },
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const updatedCharacter: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(updatedCharacter);
+      await charactersAssert.validateId(updatedCharacter.id, createdCharacterId);
+      await charactersAssert.validateSkillProficiencies(
+        updatedCharacter.skillProficiencies,
+        barbarianSkillProficiencies,
+      );
+      await charactersAssert.validateAbilityScores(
+        updatedCharacter.abilityScores,
+        barbarianAbilityScores,
+        barbarianAbilityBonuses,
+      );
+    },
+  );
+
+  test(
+    'Get Skilled Barbarian',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateSkillProficiencies(
+        character.skillProficiencies,
+        barbarianSkillProficiencies,
+      );
+    },
+  );
+
+  test(
+    'Get Skills Barbarian',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterSkills(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const skills: CharacterSkillItem[] = await response.json();
+
+      await charactersAssert.validateCharacterSkillsSchema(skills);
+      await charactersAssert.validateCharacterSkillCalculation(skills, {
+        name: 'Athletics',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        level: 1,
+      });
+      await charactersAssert.validateCharacterSkillCalculation(skills, {
+        name: 'Stealth',
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 1,
+        level: 1,
+      });
+    },
+  );
+
+  test(
     'Get Complete Barbarian',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
@@ -784,6 +892,10 @@ test.describe(
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
         expectedDetailedBackgrounds.soldier.abilityScores,
+      );
+      await charactersAssert.validateSkillProficiencies(
+        finalCharacter.skillProficiencies,
+        barbarianSkillProficiencies,
       );
       await charactersAssert.validateClassDetailsPresence(
         finalCharacter.classDetails ?? null,
@@ -2040,6 +2152,98 @@ test.describe(
   );
 
   test(
+    'Add Skills Wizard',
+    { tag: ['@patch', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.updateCharacter(
+        createdCharacterId,
+        {
+          skillProficiencies: wizardSkillProficiencies,
+        },
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const updatedCharacter: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(updatedCharacter);
+      await charactersAssert.validateId(updatedCharacter.id, createdCharacterId);
+      await charactersAssert.validateSkillProficiencies(
+        updatedCharacter.skillProficiencies,
+        wizardSkillProficiencies,
+      );
+      await charactersAssert.validateAbilityScores(
+        updatedCharacter.abilityScores,
+        wizardAbilityScores,
+        wizardAbilityBonuses,
+      );
+    },
+  );
+
+  test(
+    'Get Skilled Wizard',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateSkillProficiencies(
+        character.skillProficiencies,
+        wizardSkillProficiencies,
+      );
+    },
+  );
+
+  test(
+    'Get Skills Wizard',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterSkills(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const skills: CharacterSkillItem[] = await response.json();
+
+      await charactersAssert.validateCharacterSkillsSchema(skills);
+      await charactersAssert.validateCharacterSkillCalculation(skills, {
+        name: 'Arcana',
+        ability: 'INT',
+        isProficient: true,
+        abilityModifier: 3,
+        level: 1,
+      });
+      await charactersAssert.validateCharacterSkillCalculation(skills, {
+        name: 'Stealth',
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 2,
+        level: 1,
+      });
+    },
+  );
+
+  test(
     'Get Complete Wizard',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
@@ -2072,6 +2276,10 @@ test.describe(
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
         expectedDetailedBackgrounds.sage.abilityScores,
+      );
+      await charactersAssert.validateSkillProficiencies(
+        finalCharacter.skillProficiencies,
+        wizardSkillProficiencies,
       );
       await charactersAssert.validateClassDetailsPresence(
         finalCharacter.classDetails ?? null,

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -5,6 +5,7 @@ import {
   CharacterResolvedAbilityScores,
   CharacterClassDetails,
   CharacterListItem,
+  CharacterSkillItem,
   CharacterSpellOptionsResponseBody,
   CharacterSpellSelectionResponseBody,
   CharacterResponseBody,
@@ -55,6 +56,26 @@ export class CharactersAssert {
       WIS: this.calculateAbilityModifier(finalAbilityScores.WIS),
       CHA: this.calculateAbilityModifier(finalAbilityScores.CHA),
     };
+  }
+
+  private getProficiencyBonus(level: number): number {
+    if (level >= 17) {
+      return 6;
+    }
+
+    if (level >= 13) {
+      return 5;
+    }
+
+    if (level >= 9) {
+      return 4;
+    }
+
+    if (level >= 5) {
+      return 3;
+    }
+
+    return 2;
   }
 
   async created(response: { status(): number; ok(): boolean }) {
@@ -144,6 +165,30 @@ export class CharactersAssert {
         expect(typeof spell.name).toBe('string');
         expect(typeof spell.level).toBe('number');
         expect(typeof spell.levelLabel).toBe('string');
+      });
+    }
+  }
+
+  async validateCharacterSkillsSchema(skills: CharacterSkillItem[]) {
+    await test.step('Validate character skills schema', async () => {
+      expect(Array.isArray(skills)).toBe(true);
+    });
+
+    for (const skill of skills) {
+      await test.step(`Validate character skill schema for ${skill.name}`, async () => {
+        expect(skill).toHaveProperty('name');
+        expect(skill).toHaveProperty('ability');
+        expect(skill).toHaveProperty('isProficient');
+        expect(skill).toHaveProperty('abilityModifier');
+        expect(skill).toHaveProperty('proficiencyBonus');
+        expect(skill).toHaveProperty('total');
+
+        expect(typeof skill.name).toBe('string');
+        expect(typeof skill.ability).toBe('string');
+        expect(typeof skill.isProficient).toBe('boolean');
+        expect(typeof skill.abilityModifier).toBe('number');
+        expect(typeof skill.proficiencyBonus).toBe('number');
+        expect(typeof skill.total).toBe('number');
       });
     }
   }
@@ -278,6 +323,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('missingFields');
       expect(character).toHaveProperty('abilityScores');
       expect(character).toHaveProperty('abilityModifiers');
+      expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
       expect(character).toHaveProperty('classDetails');
       expect(character).toHaveProperty('speciesDetails');
@@ -306,6 +352,7 @@ export class CharactersAssert {
         character.abilityModifiers === null ||
           typeof character.abilityModifiers === 'object',
       ).toBe(true);
+      expect(Array.isArray(character.skillProficiencies)).toBe(true);
       expect(
         character.abilityScoreRules === null ||
           typeof character.abilityScoreRules === 'object',
@@ -328,6 +375,15 @@ export class CharactersAssert {
       await test.step(`Validate missing field schema for ${missingField}`, async () => {
         expect(typeof missingField).toBe('string');
       });
+    }
+
+    for (const skillProficiency of character.skillProficiencies) {
+      await test.step(
+        `Validate skill proficiency schema for ${skillProficiency}`,
+        async () => {
+          expect(typeof skillProficiency).toBe('string');
+        },
+      );
     }
 
     if (character.abilityScores) {
@@ -793,6 +849,42 @@ export class CharactersAssert {
         });
       });
     }
+  }
+
+  async validateSkillProficiencies(
+    skillProficiencies: CharacterResponseBody['skillProficiencies'],
+    expectedSkillProficiencies: string[],
+  ) {
+    await test.step('Validate Skill Proficiencies', async () => {
+      expect(skillProficiencies).toEqual(expectedSkillProficiencies);
+    });
+  }
+
+  async validateCharacterSkillCalculation(
+    skills: CharacterSkillItem[],
+    expected: {
+      name: string;
+      ability: string;
+      isProficient: boolean;
+      abilityModifier: number;
+      level: number;
+    },
+  ) {
+    await test.step(`Validate calculated skill for ${expected.name}`, async () => {
+      const skill = skills.find((item) => item.name === expected.name);
+
+      expect(skill).toBeDefined();
+      expect(skill?.ability).toBe(expected.ability);
+      expect(skill?.isProficient).toBe(expected.isProficient);
+      expect(skill?.abilityModifier).toBe(expected.abilityModifier);
+
+      const proficiencyBonus = expected.isProficient
+        ? this.getProficiencyBonus(expected.level)
+        : 0;
+
+      expect(skill?.proficiencyBonus).toBe(proficiencyBonus);
+      expect(skill?.total).toBe(expected.abilityModifier + proficiencyBonus);
+    });
   }
 
   async validateClassDetailsPresence(


### PR DESCRIPTION
- add skillProficiencies support to the character flow
- implement GET /api/characters/[id]/skills
- return usable character skills with ability, proficiency, and total values
- calculate skill totals from ability modifiers and proficiency bonus
- update backend logic and shared types for character skill data
- expand automated test coverage for character skills and proficiencies
- update fixtures and reusable assertions where needed
- refresh API documentation to reflect the new character skills endpoint