### PR TITLE
feat: add equipment API and expand character support flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,57 @@ Returns:
 - `404` with `{ "error": "Background not found" }` when the background does not exist
 - `500` with `{ "error": "Failed to fetch background detail" }` if the query fails
 
+### `GET /api/equipment`
+
+Returns a lightweight equipment list with:
+
+- `id`
+- `name`
+- `category`
+- `type`
+- `cost`
+- `weight`
+- `isMagical`
+
+Returns `500` with `{ "error": "Failed to fetch equipment" }` if the query fails.
+
+### `GET /api/equipment/{identifier}`
+
+Returns detailed information for a single equipment item.
+
+Supported identifiers:
+
+- numeric id, for example `/api/equipment/1`
+- slug, for example `/api/equipment/chain-mail`
+- exact name in a case-insensitive form, for example `/api/equipment/shield`
+
+Top-level response fields:
+
+- `id`
+- `name`
+- `slug`
+- `category`
+- `type`
+- `description`
+- `cost`
+- `weight`
+- `isMagical`
+- `modifiers`
+- `effects`
+- `details`
+
+The `details.kind` field currently distinguishes:
+
+- `weapon`
+- `armor`
+- `shield`
+- `generic`
+
+Returns:
+
+- `404` with `{ "error": "Equipment not found" }` when the item does not exist
+- `500` with `{ "error": "Failed to fetch equipment detail" }` if the query fails
+
 ### `GET /api/skills`
 
 Returns a lightweight skills list with:
@@ -776,6 +827,49 @@ Background detail:
     "Calligrapher's Supplies, Book (prayers), Holy Symbol, Parchment (10 sheets), Robe, 8 GP",
     "50 GP"
   ]
+}
+```
+
+Equipment detail:
+
+```json
+{
+  "id": 1,
+  "name": "Club",
+  "slug": "club",
+  "category": "Weapon",
+  "type": "Weapon",
+  "description": "A simple melee weapon.",
+  "cost": "1 sp",
+  "weight": 2,
+  "isMagical": false,
+  "modifiers": [],
+  "effects": [],
+  "details": {
+    "kind": "weapon",
+    "weaponCategory": "Simple",
+    "attackType": "Melee",
+    "damage": {
+      "formula": "1d4",
+      "dice": [{ "count": 1, "value": 4 }],
+      "bonus": 0,
+      "damageType": "Bludgeoning"
+    },
+    "versatileDamage": null,
+    "properties": [
+      {
+        "name": "Light",
+        "slug": "light"
+      }
+    ],
+    "mastery": {
+      "name": "Slow",
+      "slug": "slow"
+    },
+    "range": null,
+    "proficiencyType": "Simple Weapons",
+    "ammunitionType": null
+  }
 }
 ```
 

--- a/app/api/characters/[id]/route.ts
+++ b/app/api/characters/[id]/route.ts
@@ -2,9 +2,11 @@ import { getAuthenticatedOwnerFromRequest } from '@/app/lib/auth';
 import {
   formatCharacterResponse,
   isCharacterAbilityScoresOrNull,
+  isCharacterCurrencyOrNull,
   isNullablePositiveInteger,
   isSkillProficiencies,
   serializeCharacterAbilityScoresInput,
+  serializeCharacterCurrency,
   serializeSkillProficiencies,
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
@@ -31,6 +33,7 @@ function isCharacterUpdateRequestBody(
     (!('level' in value) || isNullablePositiveInteger(value.level)) &&
     (!('abilityScores' in value) ||
       isCharacterAbilityScoresOrNull(value.abilityScores)) &&
+    (!('currency' in value) || isCharacterCurrencyOrNull(value.currency)) &&
     (!('skillProficiencies' in value) ||
       isSkillProficiencies(value.skillProficiencies))
   );
@@ -53,7 +56,7 @@ export async function GET(request: Request, { params }: RouteContext) {
 
   try {
     const characterRows = await sql`
-      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
+      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, currency, skillproficiencies
       FROM characters
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
@@ -76,6 +79,7 @@ export async function GET(request: Request, { params }: RouteContext) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      currency: character.currency,
       skillProficiencies: character.skillproficiencies,
     });
 
@@ -115,7 +119,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
 
     const sql = getSql();
     const existingRows = await sql`
-      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
+      SELECT id, name, classid, speciesid, backgroundid, level, abilityscores, currency, skillproficiencies
       FROM characters
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
@@ -158,6 +162,12 @@ export async function PATCH(request: Request, { params }: RouteContext) {
           ? null
           : serializeCharacterAbilityScoresInput(body.abilityScores)
         : existingCharacter.abilityscores;
+    const nextCurrency =
+      body.currency !== undefined
+        ? body.currency === null
+          ? null
+          : serializeCharacterCurrency(body.currency)
+        : existingCharacter.currency;
     const nextSkillProficiencies =
       body.skillProficiencies !== undefined
         ? serializeSkillProficiencies(body.skillProficiencies)
@@ -179,11 +189,12 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         backgroundid = ${nextBackgroundId},
         level = ${nextLevel},
         abilityscores = ${nextAbilityScores},
+        currency = ${nextCurrency},
         skillproficiencies = ${nextSkillProficiencies}::jsonb,
         updatedat = NOW()
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
-      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
+      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, currency, skillproficiencies
     `;
 
     const character = characterRows[0];
@@ -195,6 +206,7 @@ export async function PATCH(request: Request, { params }: RouteContext) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      currency: character.currency,
       skillProficiencies: character.skillproficiencies,
     });
 

--- a/app/api/characters/route.ts
+++ b/app/api/characters/route.ts
@@ -4,9 +4,11 @@ import {
   getCharacterMissingFields,
   getCharacterStatus,
   isCharacterAbilityScoresOrNull,
+  isCharacterCurrencyOrNull,
   isNullablePositiveInteger,
   isSkillProficiencies,
   serializeCharacterAbilityScoresInput,
+  serializeCharacterCurrency,
   serializeSkillProficiencies,
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
@@ -35,6 +37,7 @@ function isCharacterCreateRequestBody(
     (!('level' in value) || isNullablePositiveInteger(value.level)) &&
     (!('abilityScores' in value) ||
       isCharacterAbilityScoresOrNull(value.abilityScores)) &&
+    (!('currency' in value) || isCharacterCurrencyOrNull(value.currency)) &&
     (!('skillProficiencies' in value) ||
       isSkillProficiencies(value.skillProficiencies))
   );
@@ -141,6 +144,10 @@ export async function POST(request: Request) {
       body.abilityScores === undefined || body.abilityScores === null
         ? null
         : serializeCharacterAbilityScoresInput(body.abilityScores);
+    const currency =
+      body.currency === undefined || body.currency === null
+        ? null
+        : serializeCharacterCurrency(body.currency);
     const skillProficiencies = serializeSkillProficiencies(
       body.skillProficiencies ?? [],
     );
@@ -160,6 +167,7 @@ export async function POST(request: Request) {
         backgroundid,
         level,
         abilityscores,
+        currency,
         skillproficiencies
       )
       VALUES (
@@ -171,9 +179,10 @@ export async function POST(request: Request) {
         ${backgroundId},
         ${level},
         ${abilityScores},
+        ${currency},
         ${skillProficiencies}::jsonb
       )
-      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, skillproficiencies
+      RETURNING id, name, classid, speciesid, backgroundid, level, abilityscores, currency, skillproficiencies
     `;
 
     const character = characterRows[0];
@@ -185,6 +194,7 @@ export async function POST(request: Request) {
       backgroundId: character.backgroundid,
       level: character.level,
       abilityScores: character.abilityscores,
+      currency: character.currency,
       skillProficiencies: character.skillproficiencies,
     });
 

--- a/app/api/equipment/[identifier]/route.ts
+++ b/app/api/equipment/[identifier]/route.ts
@@ -1,0 +1,442 @@
+import { getSql } from '@/app/lib/db';
+import {
+  EquipmentArmorDetails,
+  EquipmentDamage,
+  EquipmentDetail,
+  EquipmentDetails,
+  EquipmentEffect,
+  EquipmentGenericDetails,
+  EquipmentMastery,
+  EquipmentModifier,
+  EquipmentProperty,
+  EquipmentRange,
+  EquipmentShieldDetails,
+  EquipmentWeaponDetails,
+} from '@/app/types/equipment';
+import { NextResponse } from 'next/server';
+
+interface RouteContext {
+  params: Promise<{
+    identifier: string;
+  }>;
+}
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function normalizeEquipmentValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  return value;
+}
+
+function parseEquipmentModifier(value: unknown): EquipmentModifier | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const modifier = value as Record<string, unknown>;
+
+  if (
+    typeof modifier.type !== 'string' ||
+    typeof modifier.value !== 'number' ||
+    (modifier.target !== null &&
+      modifier.target !== undefined &&
+      typeof modifier.target !== 'string') ||
+    (modifier.condition !== null &&
+      modifier.condition !== undefined &&
+      typeof modifier.condition !== 'string')
+  ) {
+    return null;
+  }
+
+  return {
+    type: modifier.type as EquipmentModifier['type'],
+    value: modifier.value,
+    target:
+      modifier.target === undefined ? null : (modifier.target as string | null),
+    condition:
+      modifier.condition === undefined
+        ? null
+        : (modifier.condition as string | null),
+  };
+}
+
+function parseEquipmentEffect(value: unknown): EquipmentEffect | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const effect = value as Record<string, unknown>;
+
+  if (
+    typeof effect.name !== 'string' ||
+    typeof effect.description !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    name: effect.name,
+    description: effect.description,
+  };
+}
+
+function parseEquipmentRange(value: unknown): EquipmentRange | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const range = value as Record<string, unknown>;
+
+  if (
+    (range.normal !== null && typeof range.normal !== 'number') ||
+    (range.long !== null && typeof range.long !== 'number') ||
+    range.unit !== 'ft'
+  ) {
+    return null;
+  }
+
+  return {
+    normal: range.normal as number | null,
+    long: range.long as number | null,
+    unit: 'ft',
+  };
+}
+
+function parseEquipmentDamage(value: unknown): EquipmentDamage | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const damage = value as Record<string, unknown>;
+
+  if (
+    typeof damage.formula !== 'string' ||
+    typeof damage.bonus !== 'number' ||
+    typeof damage.damageType !== 'string' ||
+    !Array.isArray(damage.dice)
+  ) {
+    return null;
+  }
+
+  const dice = damage.dice
+    .map((entry) => {
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        return null;
+      }
+
+      const die = entry as Record<string, unknown>;
+
+      return typeof die.count === 'number' && typeof die.value === 'number'
+        ? { count: die.count, value: die.value }
+        : null;
+    })
+    .filter((entry): entry is EquipmentDamage['dice'][number] => entry !== null);
+
+  if (dice.length !== damage.dice.length) {
+    return null;
+  }
+
+  return {
+    formula: damage.formula,
+    dice,
+    bonus: damage.bonus,
+    damageType: damage.damageType,
+  };
+}
+
+function parseEquipmentProperty(value: unknown): EquipmentProperty | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const property = value as Record<string, unknown>;
+
+  if (typeof property.name !== 'string' || typeof property.slug !== 'string') {
+    return null;
+  }
+
+  const range =
+    property.range === undefined ? undefined : parseEquipmentRange(property.range);
+  const damage =
+    property.damage === undefined
+      ? undefined
+      : parseEquipmentDamage(property.damage);
+
+  if (property.range !== undefined && range === null) {
+    return null;
+  }
+
+  if (property.damage !== undefined && damage === null) {
+    return null;
+  }
+
+  if (
+    property.ammunitionType !== undefined &&
+    property.ammunitionType !== null &&
+    typeof property.ammunitionType !== 'string'
+  ) {
+    return null;
+  }
+
+  if (
+    property.note !== undefined &&
+    property.note !== null &&
+    typeof property.note !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    name: property.name,
+    slug: property.slug,
+    range: range ?? undefined,
+    ammunitionType:
+      property.ammunitionType === undefined
+        ? undefined
+        : (property.ammunitionType as string | null),
+    damage: damage ?? undefined,
+    note:
+      property.note === undefined ? undefined : (property.note as string | null),
+  };
+}
+
+function parseEquipmentMastery(value: unknown): EquipmentMastery | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const mastery = value as Record<string, unknown>;
+
+  if (typeof mastery.name !== 'string' || typeof mastery.slug !== 'string') {
+    return null;
+  }
+
+  return {
+    name: mastery.name,
+    slug: mastery.slug,
+  };
+}
+
+function parseWeaponDetails(value: unknown): EquipmentWeaponDetails | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const details = value as Record<string, unknown>;
+
+  if (
+    details.kind !== 'weapon' ||
+    typeof details.weaponCategory !== 'string' ||
+    typeof details.attackType !== 'string' ||
+    typeof details.proficiencyType !== 'string'
+  ) {
+    return null;
+  }
+
+  const damage = parseEquipmentDamage(details.damage);
+  const versatileDamage =
+    details.versatileDamage === null
+      ? null
+      : parseEquipmentDamage(details.versatileDamage);
+  const range =
+    details.range === null ? null : parseEquipmentRange(details.range);
+  const mastery = parseEquipmentMastery(details.mastery);
+
+  if (
+    damage === null ||
+    versatileDamage === undefined ||
+    range === undefined ||
+    mastery === null ||
+    !Array.isArray(details.properties)
+  ) {
+    return null;
+  }
+
+  const properties = details.properties
+    .map(parseEquipmentProperty)
+    .filter((property): property is EquipmentProperty => property !== null);
+
+  if (properties.length !== details.properties.length) {
+    return null;
+  }
+
+  if (
+    details.ammunitionType !== undefined &&
+    details.ammunitionType !== null &&
+    typeof details.ammunitionType !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'weapon',
+    weaponCategory: details.weaponCategory,
+    attackType: details.attackType,
+    damage,
+    versatileDamage,
+    properties,
+    mastery,
+    range,
+    proficiencyType: details.proficiencyType,
+    ammunitionType:
+      details.ammunitionType === undefined
+        ? null
+        : (details.ammunitionType as string | null),
+  };
+}
+
+function parseArmorDetails(value: unknown): EquipmentArmorDetails | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const details = value as Record<string, unknown>;
+
+  if (details.kind !== 'armor') {
+    return null;
+  }
+
+  return details as unknown as EquipmentArmorDetails;
+}
+
+function parseShieldDetails(value: unknown): EquipmentShieldDetails | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const details = value as Record<string, unknown>;
+
+  if (details.kind !== 'shield') {
+    return null;
+  }
+
+  return details as unknown as EquipmentShieldDetails;
+}
+
+function parseEquipmentDetails(value: unknown): EquipmentDetails {
+  const parsedValue = parseJsonValue(value);
+
+  return (
+    parseWeaponDetails(parsedValue) ??
+    parseArmorDetails(parsedValue) ??
+    parseShieldDetails(parsedValue) ??
+    ({ kind: 'generic' } satisfies EquipmentGenericDetails)
+  );
+}
+
+function parseEquipmentModifiers(value: unknown): EquipmentModifier[] {
+  const parsedValue = parseJsonValue(value);
+
+  return Array.isArray(parsedValue)
+    ? parsedValue
+        .map(parseEquipmentModifier)
+        .filter((modifier): modifier is EquipmentModifier => modifier !== null)
+    : [];
+}
+
+function parseEquipmentEffects(value: unknown): EquipmentEffect[] {
+  const parsedValue = parseJsonValue(value);
+
+  return Array.isArray(parsedValue)
+    ? parsedValue
+        .map(parseEquipmentEffect)
+        .filter((effect): effect is EquipmentEffect => effect !== null)
+    : [];
+}
+
+export async function GET(_: Request, { params }: RouteContext) {
+  const { identifier } = await params;
+  const parsedId = Number(identifier);
+  const sql = getSql();
+
+  try {
+    let equipmentRows;
+
+    if (!Number.isNaN(parsedId)) {
+      equipmentRows = await sql`
+        SELECT
+          id,
+          name,
+          slug,
+          category,
+          type,
+          description,
+          cost,
+          weight,
+          ismagical,
+          details,
+          modifiers,
+          effects
+        FROM equipment
+        WHERE id = ${parsedId}
+      `;
+    } else {
+      const normalizedIdentifier = normalizeEquipmentValue(identifier);
+
+      equipmentRows = await sql`
+        SELECT
+          id,
+          name,
+          slug,
+          category,
+          type,
+          description,
+          cost,
+          weight,
+          ismagical,
+          details,
+          modifiers,
+          effects
+        FROM equipment
+        WHERE LOWER(name) = ${normalizedIdentifier}
+          OR LOWER(slug) = ${normalizedIdentifier}
+      `;
+    }
+
+    if (!equipmentRows || equipmentRows.length === 0) {
+      return NextResponse.json(
+        { error: 'Equipment not found' },
+        { status: 404 },
+      );
+    }
+
+    const item = equipmentRows[0];
+
+    const formattedEquipment: EquipmentDetail = {
+      id: toNumber(item.id),
+      name: item.name,
+      slug: item.slug,
+      category: item.category,
+      type: item.type,
+      description: item.description,
+      cost: item.cost,
+      weight: item.weight === null ? null : toNumber(item.weight),
+      isMagical: Boolean(item.ismagical),
+      modifiers: parseEquipmentModifiers(item.modifiers),
+      effects: parseEquipmentEffects(item.effects),
+      details: parseEquipmentDetails(item.details),
+    };
+
+    return NextResponse.json(formattedEquipment, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch equipment detail:', error);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch equipment detail' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/equipment/route.ts
+++ b/app/api/equipment/route.ts
@@ -1,0 +1,38 @@
+import { getSql } from '@/app/lib/db';
+import { EquipmentListItem } from '@/app/types/equipment';
+import { NextResponse } from 'next/server';
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+export async function GET() {
+  const sql = getSql();
+
+  try {
+    const equipmentRows = await sql`
+      SELECT id, name, category, type, cost, weight, ismagical
+      FROM equipment
+      ORDER BY id
+    `;
+
+    const equipment: EquipmentListItem[] = equipmentRows.map((item) => ({
+      id: toNumber(item.id),
+      name: item.name,
+      category: item.category,
+      type: item.type,
+      cost: item.cost,
+      weight: item.weight === null ? null : toNumber(item.weight),
+      isMagical: Boolean(item.ismagical),
+    }));
+
+    return NextResponse.json(equipment, { status: 200 });
+  } catch (error) {
+    console.error('Failed to fetch equipment:', error);
+
+    return NextResponse.json(
+      { error: 'Failed to fetch equipment' },
+      { status: 500 },
+    );
+  }
+}

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -32,6 +32,25 @@ export const apiResources: ApiResource[] = [
     ],
   },
   {
+    name: 'Equipment',
+    slug: 'equipment',
+    description:
+      'Equipment catalog with list and detail endpoints covering weapons, armor, shields, and generic adventuring gear.',
+    summary:
+      'Provides lightweight listing plus richer detail payloads with typed equipment-specific fields.',
+    listFields: [
+      'id',
+      'name',
+      'category',
+      'type',
+      'cost',
+      'weight',
+      'isMagical',
+    ],
+    previewFields: ['category', 'type', 'cost', 'details'],
+    endpoints: ['GET /api/equipment', 'GET /api/equipment/{identifier}'],
+  },
+  {
     name: 'Skills',
     slug: 'skills',
     description:
@@ -140,5 +159,6 @@ export const apiResources: ApiResource[] = [
 export const projectHighlights = [
   'Visual entrypoint for the API project',
   'Interactive documentation available in /docs',
+  'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support creation, updates, deletion, calculated skills, and richer detail payloads',
 ];

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -6,6 +6,7 @@ import {
   CharacterAbilityScoreBonusRules,
   CharacterAbilityScoreRuleOption,
   CharacterAbilityScoreRuleOptionPlusTwoPlusOne,
+  CharacterCurrency,
   CharacterAbilityScoreRules,
   CharacterClassDetails,
   CharacterMissingField,
@@ -259,6 +260,64 @@ export function serializeSkillProficiencies(value: SkillName[]): string {
   return JSON.stringify([...new Set(value)]);
 }
 
+export function isCharacterCurrency(value: unknown): value is CharacterCurrency {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const currency = value as Record<string, unknown>;
+
+  return (
+    typeof currency.cp === 'number' &&
+    typeof currency.sp === 'number' &&
+    typeof currency.ep === 'number' &&
+    typeof currency.gp === 'number' &&
+    typeof currency.pp === 'number'
+  );
+}
+
+export function isCharacterCurrencyOrNull(
+  value: unknown,
+): value is CharacterCurrency | null {
+  return value === null || isCharacterCurrency(value);
+}
+
+export function parseCharacterCurrency(value: unknown): CharacterCurrency | null {
+  if (isCharacterCurrency(value)) {
+    return {
+      cp: value.cp,
+      sp: value.sp,
+      ep: value.ep,
+      gp: value.gp,
+      pp: value.pp,
+    };
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+
+      return parseCharacterCurrency(parsed);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export function serializeCharacterCurrency(
+  value: CharacterCurrency,
+): CharacterCurrency {
+  return {
+    cp: value.cp,
+    sp: value.sp,
+    ep: value.ep,
+    gp: value.gp,
+    pp: value.pp,
+  };
+}
+
 export function getProficiencyBonus(level: number): number {
   if (level >= 17) {
     return 6;
@@ -499,6 +558,7 @@ export async function formatCharacterResponse(character: {
     | CharacterResolvedAbilityScores
     | string
     | null;
+  currency?: CharacterCurrency | string | null;
   skillProficiencies?: SkillName[] | string | null;
 }): Promise<CharacterResponseBody> {
   const formattedCharacter = {
@@ -514,6 +574,7 @@ export async function formatCharacterResponse(character: {
     abilityScores: parseCharacterAbilityScores(
       character.abilityScores ?? null,
     ),
+    currency: parseCharacterCurrency(character.currency ?? null),
     skillProficiencies: parseSkillProficiencies(
       character.skillProficiencies ?? [],
     ),
@@ -546,6 +607,7 @@ export async function formatCharacterResponse(character: {
     missingFields,
     abilityScores: formattedCharacter.abilityScores,
     abilityModifiers,
+    currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,
     classDetails,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,8 +69,8 @@ export default function HomePage() {
           <h2>Resources currently open in the realm</h2>
           <p>
             Each card reads like a compact ledger entry, showing what is already
-            implemented and where to inspect the list and detail routes for that
-            resource.
+            implemented across the growing reference catalogs and authenticated
+            character workflows, plus where to inspect the related routes.
           </p>
         </div>
 

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -25,7 +25,8 @@ export default function SupportPage() {
               Adventurers Guild API is a fantasy-themed REST API built to
               support backend practice, documentation, automation, and contract
               validation while also offering a more atmospheric and welcoming
-              frontend for new visitors.
+              frontend for new visitors, with growing coverage for reference
+              catalogs like equipment and richer character management flows.
             </p>
           </article>
 

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -62,6 +62,14 @@ export interface CharacterAbilityModifiers {
   CHA: number;
 }
 
+export interface CharacterCurrency {
+  cp: number;
+  sp: number;
+  ep: number;
+  gp: number;
+  pp: number;
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -100,6 +108,7 @@ export interface CharacterCreateRequestBody {
   backgroundId?: number | null;
   level?: number | null;
   abilityScores?: CharacterAbilityScoresInput | null;
+  currency?: CharacterCurrency | null;
   skillProficiencies?: SkillName[];
 }
 
@@ -110,6 +119,7 @@ export interface CharacterUpdateRequestBody {
   backgroundId?: number | null;
   level?: number | null;
   abilityScores?: CharacterAbilityScoresInput | null;
+  currency?: CharacterCurrency | null;
   skillProficiencies?: SkillName[];
 }
 
@@ -131,6 +141,7 @@ export interface CharacterResponseBody {
   missingFields: CharacterMissingField[];
   abilityScores: CharacterResolvedAbilityScores | null;
   abilityModifiers: CharacterAbilityModifiers | null;
+  currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;
   classDetails?: CharacterClassDetails | null;

--- a/app/types/equipment.ts
+++ b/app/types/equipment.ts
@@ -1,0 +1,125 @@
+export interface EquipmentListItem {
+  id: number;
+  name: string;
+  category: string;
+  type: string;
+  cost: string;
+  weight: number | null;
+  isMagical: boolean;
+}
+
+export interface EquipmentDamageDice {
+  count: number;
+  value: number;
+}
+
+export interface EquipmentDamage {
+  formula: string;
+  dice: EquipmentDamageDice[];
+  bonus: number;
+  damageType: string;
+}
+
+export interface EquipmentRange {
+  normal: number | null;
+  long: number | null;
+  unit: 'ft';
+}
+
+export interface EquipmentProperty {
+  name: string;
+  slug: string;
+  range?: EquipmentRange | null;
+  ammunitionType?: string | null;
+  damage?: EquipmentDamage | null;
+  note?: string | null;
+}
+
+export interface EquipmentMastery {
+  name: string;
+  slug: string;
+}
+
+export interface EquipmentArmorClass {
+  base: number;
+  dexModifier: {
+    applies: boolean;
+    max: number | null;
+  };
+}
+
+export interface EquipmentModifier {
+  type:
+    | 'attackBonus'
+    | 'damageBonus'
+    | 'armorClassBonus'
+    | 'abilityScoreBonus'
+    | 'skillBonus'
+    | 'savingThrowBonus'
+    | 'speedBonus';
+  value: number;
+  target: string | null;
+  condition: string | null;
+}
+
+export interface EquipmentEffect {
+  name: string;
+  description: string;
+}
+
+export interface EquipmentWeaponDetails {
+  kind: 'weapon';
+  weaponCategory: string;
+  attackType: string;
+  damage: EquipmentDamage;
+  versatileDamage: EquipmentDamage | null;
+  properties: EquipmentProperty[];
+  mastery: EquipmentMastery;
+  range: EquipmentRange | null;
+  proficiencyType: string;
+  ammunitionType: string | null;
+}
+
+export interface EquipmentArmorDetails {
+  kind: 'armor';
+  armorType: string;
+  trainingType: string;
+  armorClass: EquipmentArmorClass;
+  strengthRequirement: number | null;
+  stealthDisadvantage: boolean;
+  donTime: string;
+  doffTime: string;
+}
+
+export interface EquipmentShieldDetails {
+  kind: 'shield';
+  trainingType: string;
+  armorClassBonus: number;
+  donTime: string;
+  doffTime: string;
+}
+
+export interface EquipmentGenericDetails {
+  kind: 'generic';
+}
+
+export type EquipmentDetails =
+  | EquipmentWeaponDetails
+  | EquipmentArmorDetails
+  | EquipmentShieldDetails
+  | EquipmentGenericDetails;
+
+export interface EquipmentDetail {
+  id: number;
+  name: string;
+  slug: string;
+  category: string;
+  type: string;
+  description: string;
+  cost: string;
+  weight: number | null;
+  isMagical: boolean;
+  modifiers: EquipmentModifier[];
+  effects: EquipmentEffect[];
+  details: EquipmentDetails;
+}

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.8.0
+  version: 1.9.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -11,6 +11,7 @@ info:
     - Auth token issuance
     - Attributes list
     - Backgrounds list and detail
+    - Equipment list and detail
     - Skills list and detail
     - Classes list and detail
     - Spells list and detail
@@ -30,6 +31,8 @@ tags:
     description: Core RPG attributes such as Strength, Dexterity, and Wisdom.
   - name: Backgrounds
     description: Character backgrounds list and detail endpoints.
+  - name: Equipment
+    description: Equipment list and detail endpoints for weapons, armor, shields, and generic gear.
   - name: Skills
     description: Skills list and skill detail endpoints.
   - name: Classes
@@ -49,6 +52,7 @@ x-tagGroups:
     tags:
       - Attributes
       - Backgrounds
+      - Equipment
       - Skills
       - Classes
       - Spells
@@ -273,6 +277,137 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
               example:
                 error: Failed to fetch background detail
+
+  /api/equipment:
+    get:
+      tags:
+        - Equipment
+      operationId: getEquipment
+      summary: List all equipment
+      description: |
+        Returns a lightweight list of equipment items.
+      responses:
+        '200':
+          description: Equipment returned successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EquipmentListItem'
+              example:
+                - id: 1
+                  name: Club
+                  category: Weapon
+                  type: Weapon
+                  cost: 1 sp
+                  weight: 2
+                  isMagical: false
+                - id: 58
+                  name: Chain Mail
+                  category: Armor
+                  type: Armor
+                  cost: 75 gp
+                  weight: 55
+                  isMagical: false
+        '500':
+          description: Failed to fetch equipment
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch equipment
+
+  /api/equipment/{identifier}:
+    get:
+      tags:
+        - Equipment
+      operationId: getEquipmentByIdentifier
+      summary: Get equipment detail by identifier
+      description: |
+        Returns detailed information about a single equipment item.
+
+        Supported identifiers:
+        - numeric id, for example `/api/equipment/1`
+        - slug, for example `/api/equipment/chain-mail`
+        - exact name in case-insensitive form, for example `/api/equipment/shield`
+      parameters:
+        - name: identifier
+          in: path
+          required: true
+          description: Equipment id, slug, or exact name.
+          schema:
+            oneOf:
+              - type: integer
+                minimum: 1
+              - type: string
+          examples:
+            byId:
+              summary: Lookup by id
+              value: 1
+            bySlug:
+              summary: Lookup by slug
+              value: chain-mail
+            byName:
+              summary: Lookup by name
+              value: Shield
+      responses:
+        '200':
+          description: Equipment found successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentDetail'
+              example:
+                id: 1
+                name: Club
+                slug: club
+                category: Weapon
+                type: Weapon
+                description: A simple melee weapon.
+                cost: 1 sp
+                weight: 2
+                isMagical: false
+                modifiers: []
+                effects: []
+                details:
+                  kind: weapon
+                  weaponCategory: Simple
+                  attackType: Melee
+                  damage:
+                    formula: 1d4
+                    dice:
+                      - count: 1
+                        value: 4
+                    bonus: 0
+                    damageType: Bludgeoning
+                  versatileDamage: null
+                  properties:
+                    - name: Light
+                      slug: light
+                  mastery:
+                    name: Slow
+                    slug: slow
+                  range: null
+                  proficiencyType: Simple Weapons
+                  ammunitionType: null
+        '404':
+          description: Equipment not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Equipment not found
+        '500':
+          description: Failed to fetch equipment detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Failed to fetch equipment detail
 
   /api/skills:
     get:
@@ -1933,6 +2068,389 @@ components:
           example:
             - Calligrapher's Supplies, Book (prayers), Holy Symbol, Parchment (10 sheets), Robe, 8 GP
             - 50 GP
+
+    EquipmentListItem:
+      type: object
+      required:
+        - id
+        - name
+        - category
+        - type
+        - cost
+        - weight
+        - isMagical
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Club
+        category:
+          type: string
+          example: Weapon
+        type:
+          type: string
+          example: Weapon
+        cost:
+          type: string
+          example: 1 sp
+        weight:
+          type: number
+          nullable: true
+          example: 2
+        isMagical:
+          type: boolean
+          example: false
+
+    EquipmentDamageDie:
+      type: object
+      required:
+        - count
+        - value
+      properties:
+        count:
+          type: integer
+          example: 1
+        value:
+          type: integer
+          example: 4
+
+    EquipmentDamage:
+      type: object
+      required:
+        - formula
+        - dice
+        - bonus
+        - damageType
+      properties:
+        formula:
+          type: string
+          example: 1d4
+        dice:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentDamageDie'
+        bonus:
+          type: integer
+          example: 0
+        damageType:
+          type: string
+          example: Bludgeoning
+
+    EquipmentRange:
+      type: object
+      required:
+        - normal
+        - long
+        - unit
+      properties:
+        normal:
+          type: integer
+          nullable: true
+          example: 20
+        long:
+          type: integer
+          nullable: true
+          example: 60
+        unit:
+          type: string
+          enum:
+            - ft
+          example: ft
+
+    EquipmentProperty:
+      type: object
+      required:
+        - name
+        - slug
+      properties:
+        name:
+          type: string
+          example: Thrown
+        slug:
+          type: string
+          example: thrown
+        range:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EquipmentRange'
+        ammunitionType:
+          type: string
+          nullable: true
+          example: Arrow
+        damage:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EquipmentDamage'
+        note:
+          type: string
+          nullable: true
+          example: unless mounted
+
+    EquipmentMastery:
+      type: object
+      required:
+        - name
+        - slug
+      properties:
+        name:
+          type: string
+          example: Slow
+        slug:
+          type: string
+          example: slow
+
+    EquipmentArmorClass:
+      type: object
+      required:
+        - base
+        - dexModifier
+      properties:
+        base:
+          type: integer
+          example: 16
+        dexModifier:
+          type: object
+          required:
+            - applies
+            - max
+          properties:
+            applies:
+              type: boolean
+              example: false
+            max:
+              type: integer
+              nullable: true
+              example: null
+
+    EquipmentModifier:
+      type: object
+      required:
+        - type
+        - value
+        - target
+        - condition
+      properties:
+        type:
+          type: string
+          enum:
+            - attackBonus
+            - damageBonus
+            - armorClassBonus
+            - abilityScoreBonus
+            - skillBonus
+            - savingThrowBonus
+            - speedBonus
+          example: armorClassBonus
+        value:
+          type: integer
+          example: 1
+        target:
+          type: string
+          nullable: true
+          example: AC
+        condition:
+          type: string
+          nullable: true
+          example: while equipped
+
+    EquipmentEffect:
+      type: object
+      required:
+        - name
+        - description
+      properties:
+        name:
+          type: string
+          example: Stealth Disadvantage
+        description:
+          type: string
+          example: You have disadvantage on Dexterity (Stealth) checks while wearing this armor.
+
+    EquipmentWeaponDetails:
+      type: object
+      required:
+        - kind
+        - weaponCategory
+        - attackType
+        - damage
+        - versatileDamage
+        - properties
+        - mastery
+        - range
+        - proficiencyType
+        - ammunitionType
+      properties:
+        kind:
+          type: string
+          enum:
+            - weapon
+        weaponCategory:
+          type: string
+          example: Simple
+        attackType:
+          type: string
+          example: Melee
+        damage:
+          $ref: '#/components/schemas/EquipmentDamage'
+        versatileDamage:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EquipmentDamage'
+        properties:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentProperty'
+        mastery:
+          $ref: '#/components/schemas/EquipmentMastery'
+        range:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EquipmentRange'
+        proficiencyType:
+          type: string
+          example: Simple Weapons
+        ammunitionType:
+          type: string
+          nullable: true
+          example: null
+
+    EquipmentArmorDetails:
+      type: object
+      required:
+        - kind
+        - armorType
+        - trainingType
+        - armorClass
+        - strengthRequirement
+        - stealthDisadvantage
+        - donTime
+        - doffTime
+      properties:
+        kind:
+          type: string
+          enum:
+            - armor
+        armorType:
+          type: string
+          example: Heavy Armor
+        trainingType:
+          type: string
+          example: Heavy Armor
+        armorClass:
+          $ref: '#/components/schemas/EquipmentArmorClass'
+        strengthRequirement:
+          type: integer
+          nullable: true
+          example: 13
+        stealthDisadvantage:
+          type: boolean
+          example: true
+        donTime:
+          type: string
+          example: 5 minutes
+        doffTime:
+          type: string
+          example: 1 minute
+
+    EquipmentShieldDetails:
+      type: object
+      required:
+        - kind
+        - trainingType
+        - armorClassBonus
+        - donTime
+        - doffTime
+      properties:
+        kind:
+          type: string
+          enum:
+            - shield
+        trainingType:
+          type: string
+          example: Shield
+        armorClassBonus:
+          type: integer
+          example: 2
+        donTime:
+          type: string
+          example: 1 action
+        doffTime:
+          type: string
+          example: 1 action
+
+    EquipmentGenericDetails:
+      type: object
+      required:
+        - kind
+      properties:
+        kind:
+          type: string
+          enum:
+            - generic
+
+    EquipmentDetails:
+      oneOf:
+        - $ref: '#/components/schemas/EquipmentWeaponDetails'
+        - $ref: '#/components/schemas/EquipmentArmorDetails'
+        - $ref: '#/components/schemas/EquipmentShieldDetails'
+        - $ref: '#/components/schemas/EquipmentGenericDetails'
+
+    EquipmentDetail:
+      type: object
+      required:
+        - id
+        - name
+        - slug
+        - category
+        - type
+        - description
+        - cost
+        - weight
+        - isMagical
+        - modifiers
+        - effects
+        - details
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Club
+        slug:
+          type: string
+          example: club
+        category:
+          type: string
+          example: Weapon
+        type:
+          type: string
+          example: Weapon
+        description:
+          type: string
+          example: A simple melee weapon.
+        cost:
+          type: string
+          example: 1 sp
+        weight:
+          type: number
+          nullable: true
+          example: 2
+        isMagical:
+          type: boolean
+          example: false
+        modifiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentModifier'
+        effects:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentEffect'
+        details:
+          $ref: '#/components/schemas/EquipmentDetails'
 
     SkillListItem:
       type: object

--- a/tests/clients/equipment.client.ts
+++ b/tests/clients/equipment.client.ts
@@ -1,0 +1,13 @@
+import { APIRequestContext, APIResponse } from '@playwright/test';
+
+export class EquipmentClient {
+  constructor(private readonly request: APIRequestContext) {}
+
+  async getEquipment(): Promise<APIResponse> {
+    return this.request.get('/api/equipment');
+  }
+
+  async getEquipmentDetail(identifier: number | string): Promise<APIResponse> {
+    return this.request.get(`/api/equipment/${identifier}`);
+  }
+}

--- a/tests/data/equipment.expected.ts
+++ b/tests/data/equipment.expected.ts
@@ -1,0 +1,127 @@
+import { EquipmentListItem } from '@/app/types/equipment';
+
+export const expectedEquipmentSamples = {
+  club: {
+    name: 'Club',
+    slug: 'club',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['light'],
+  },
+  dagger: {
+    name: 'Dagger',
+    slug: 'dagger',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['finesse', 'light', 'thrown'],
+    thrownRange: { normal: 20, long: 60, unit: 'ft' as const },
+  },
+  quarterstaff: {
+    name: 'Quarterstaff',
+    slug: 'quarterstaff',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['versatile'],
+  },
+  spear: {
+    name: 'Spear',
+    slug: 'spear',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    proficiencyType: 'Simple Weapons',
+    propertySlugs: ['thrown', 'versatile'],
+    thrownRange: { normal: 20, long: 60, unit: 'ft' as const },
+    masterySlug: 'sap',
+  },
+  shortbow: {
+    name: 'Shortbow',
+    slug: 'shortbow',
+    kind: 'weapon' as const,
+    attackType: 'Ranged',
+    propertySlugs: ['ammunition', 'two-handed'],
+    ammunitionType: 'Arrow',
+  },
+  sling: {
+    name: 'Sling',
+    slug: 'sling',
+    kind: 'weapon' as const,
+    attackType: 'Ranged',
+    ammunitionType: 'Bullet',
+    damageType: 'Bludgeoning',
+  },
+  glaive: {
+    name: 'Glaive',
+    slug: 'glaive',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['heavy', 'reach', 'two-handed'],
+    masterySlug: 'graze',
+  },
+  rapier: {
+    name: 'Rapier',
+    slug: 'rapier',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['finesse'],
+  },
+  lance: {
+    name: 'Lance',
+    slug: 'lance',
+    kind: 'weapon' as const,
+    attackType: 'Melee',
+    propertySlugs: ['reach', 'two-handed'],
+    twoHandedNote: 'unless mounted',
+  },
+  pistol: {
+    name: 'Pistol',
+    slug: 'pistol',
+    kind: 'weapon' as const,
+    attackType: 'Ranged',
+    propertySlugs: ['ammunition', 'loading'],
+    ammunitionType: 'Bullet',
+  },
+  blowgun: {
+    name: 'Blowgun',
+    slug: 'blowgun',
+    kind: 'weapon' as const,
+    attackType: 'Ranged',
+    ammunitionType: 'Needle',
+    damageFormula: '1',
+    damageBonus: 1,
+  },
+  chainMail: {
+    name: 'Chain Mail',
+    slug: 'chain-mail',
+    kind: 'armor' as const,
+    strengthRequirement: 13,
+    stealthDisadvantage: true,
+  },
+  shield: {
+    name: 'Shield',
+    slug: 'shield',
+    kind: 'shield' as const,
+    trainingType: 'Shield',
+    armorClassBonus: 2,
+  },
+  thievesTools: {
+    name: "Thieves' Tools",
+    slug: 'thieves-tools',
+    kind: 'generic' as const,
+  },
+};
+
+export const expectedEquipmentListSamples: Pick<
+  EquipmentListItem,
+  'name' | 'category' | 'type'
+>[] = [
+  {
+    name: expectedEquipmentSamples.spear.name,
+    category: 'Weapon',
+    type: 'Weapon',
+  },
+  {
+    name: expectedEquipmentSamples.chainMail.name,
+    category: 'Armor',
+    type: 'Armor',
+  },
+];

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -3,6 +3,7 @@ import {
   CharacterAbilityScoreOptionsResponseBody,
   CharacterAbilityScoresInput,
   CharacterAbilityScores,
+  CharacterCurrency,
   CharacterSkillItem,
   CharacterListItem,
   CharacterResponseBody,
@@ -107,6 +108,22 @@ const patchedDraftAbilityScoresInput: CharacterAbilityScoresInput = {
     WIS: 0,
     CHA: 0,
   },
+};
+
+const initialCurrency: CharacterCurrency = {
+  cp: 0,
+  sp: 5,
+  ep: 0,
+  gp: 12,
+  pp: 0,
+};
+
+const patchedCurrency: CharacterCurrency = {
+  cp: 10,
+  sp: 4,
+  ep: 0,
+  gp: 25,
+  pp: 1,
 };
 
 const barbarianSkillProficiencies: SkillName[] = [
@@ -2333,8 +2350,8 @@ test.describe(
 );
 
 test.describe(
-  'Characters API - Ability Scores',
-  { tag: ['@characters', '@ability-scores'] },
+  'Characters API - Ability Scores And Currency',
+  { tag: ['@characters', '@ability-scores', '@currency'] },
   () => {
   test.describe.configure({ mode: 'serial' });
 
@@ -2342,6 +2359,9 @@ test.describe(
   let noScoresCharacterId: number;
   let withScoresCharacterId: number;
   let patchScoresCharacterId: number;
+  let noCurrencyCharacterId: number;
+  let withCurrencyCharacterId: number;
+  let patchCurrencyCharacterId: number;
 
   test.beforeAll(async ({ request }) => {
     authToken = await issueDemoToken(request);
@@ -2368,6 +2388,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2390,6 +2411,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2419,6 +2441,7 @@ test.describe(
         character.abilityScores,
         patchedDraftAbilityScores,
       );
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2444,6 +2467,7 @@ test.describe(
         character.abilityScores,
         patchedDraftAbilityScores,
       );
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2484,6 +2508,7 @@ test.describe(
         character.abilityScores,
         patchedDraftAbilityScores,
       );
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2509,6 +2534,7 @@ test.describe(
         character.abilityScores,
         patchedDraftAbilityScores,
       );
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2534,6 +2560,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2556,6 +2583,208 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateCurrency(character.currency, null);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Create No Currency',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: `No Currency ${Date.now()}`,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+      noCurrencyCharacterId = character.id;
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, null);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Get No Currency',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        noCurrencyCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, null);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Create With Currency',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: `With Currency ${Date.now()}`,
+          currency: initialCurrency,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+      withCurrencyCharacterId = character.id;
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, initialCurrency);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Get With Currency',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        withCurrencyCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, initialCurrency);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Patch Currency',
+    { tag: ['@patch', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const createResponse = await charactersClient.createCharacter(
+        {
+          name: `Patch Currency ${Date.now()}`,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(createResponse);
+
+      const createdCharacter: CharacterResponseBody = await createResponse.json();
+      patchCurrencyCharacterId = createdCharacter.id;
+
+      const response = await charactersClient.updateCharacter(
+        patchCurrencyCharacterId,
+        {
+          currency: patchedCurrency,
+        },
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, patchedCurrency);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Get Patched Currency',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        patchCurrencyCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, patchedCurrency);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Clear Currency',
+    { tag: ['@patch', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.updateCharacter(
+        patchCurrencyCharacterId,
+        {
+          currency: null,
+        },
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, null);
+      await charactersAssert.validateStatus(character.status, 'draft');
+    },
+  );
+
+  test(
+    'Get Cleared Currency',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        patchCurrencyCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'draft');
     },
   );
@@ -2948,6 +3177,79 @@ test.describe(
               CHA: 0,
             },
           } as unknown as CharacterAbilityScoresInput,
+        },
+        token,
+      );
+
+      await charactersAssert.badRequest(response);
+
+      const body: { error: string } = await response.json();
+
+      await charactersAssert.validateErrorResponse(
+        body,
+        'Invalid character request payload',
+      );
+    },
+  );
+
+  test(
+    'Create character with incomplete currency',
+    { tag: ['@post', '@negative', '@error'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const token = await issueDemoToken(request);
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: `Incomplete Currency ${Date.now()}`,
+          currency: {
+            gp: 10,
+          } as unknown as CharacterCurrency,
+        },
+        token,
+      );
+
+      await charactersAssert.badRequest(response);
+
+      const body: { error: string } = await response.json();
+
+      await charactersAssert.validateErrorResponse(
+        body,
+        'Invalid character request payload',
+      );
+    },
+  );
+
+  test(
+    'Patch character with non-numeric currency',
+    { tag: ['@post', '@patch', '@negative', '@error'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const token = await issueDemoToken(request);
+
+      const createResponse = await charactersClient.createCharacter(
+        {
+          name: `Invalid Currency ${Date.now()}`,
+        },
+        token,
+      );
+
+      await charactersAssert.created(createResponse);
+
+      const createdCharacter: CharacterResponseBody = await createResponse.json();
+
+      const response = await charactersClient.updateCharacter(
+        createdCharacter.id,
+        {
+          currency: {
+            cp: 0,
+            sp: '5',
+            ep: 0,
+            gp: 12,
+            pp: 0,
+          } as unknown as CharacterCurrency,
         },
         token,
       );

--- a/tests/features/equipment.spec.ts
+++ b/tests/features/equipment.spec.ts
@@ -1,0 +1,499 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+
+import { EquipmentClient } from '../clients/equipment.client';
+import { expectedEquipmentListSamples, expectedEquipmentSamples } from '../data/equipment.expected';
+import { EquipmentAssert } from '../helpers/equipment.assertions';
+import {
+  EquipmentDetail,
+  EquipmentListItem,
+} from '@/app/types/equipment';
+
+test.describe('Equipment API', { tag: ['@equipment'] }, () => {
+  async function getEquipmentDetailBySlug(
+    request: APIRequestContext,
+    slug: string,
+  ) {
+    const equipmentClient = new EquipmentClient(request);
+    const equipmentAssert = new EquipmentAssert();
+
+    const response = await equipmentClient.getEquipmentDetail(slug);
+    await equipmentAssert.success(response);
+
+    const equipment: EquipmentDetail = await response.json();
+
+    await equipmentAssert.validateEquipmentDetailSchema(equipment);
+    expect(equipment.details.kind).not.toBe('generic');
+
+    return { equipment, equipmentAssert };
+  }
+
+  test(
+    'List equipment',
+    { tag: ['@get', '@smoke', '@data'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const response = await equipmentClient.getEquipment();
+
+      await equipmentAssert.success(response);
+
+      const equipment: EquipmentListItem[] = await response.json();
+
+      await equipmentAssert.validateEquipmentListSchema(equipment);
+
+      await test.step('Validate sample weapon and armor are present in list', async () => {
+        expect(
+          equipment.some((item) => item.name === expectedEquipmentListSamples[0].name),
+        ).toBe(true);
+        expect(
+          equipment.some((item) => item.name === expectedEquipmentListSamples[1].name),
+        ).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'Weapon simple melee light',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.club.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.name).toBe(expectedEquipmentSamples.club.name);
+        expect(equipment.details.attackType).toBe(
+          expectedEquipmentSamples.club.attackType,
+        );
+        expect(equipment.details.versatileDamage).toBeNull();
+        expect(equipment.details.range).toBeNull();
+        expect(equipment.details.ammunitionType).toBeNull();
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.club.propertySlugs),
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon simple melee thrown',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.dagger.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.name).toBe(expectedEquipmentSamples.dagger.name);
+        expect(equipment.details.attackType).toBe(
+          expectedEquipmentSamples.dagger.attackType,
+        );
+        expect(equipment.details.range).toBeNull();
+        expect(equipment.details.ammunitionType).toBeNull();
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.dagger.propertySlugs),
+        );
+
+        const thrownProperty = equipment.details.properties.find(
+          (property) => property.slug === 'thrown',
+        );
+
+        expect(thrownProperty?.range).toEqual(
+          expectedEquipmentSamples.dagger.thrownRange,
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon simple melee versatile',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.quarterstaff.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.versatileDamage).not.toBeNull();
+        expect(equipment.details.range).toBeNull();
+
+        const versatileProperty = equipment.details.properties.find(
+          (property) => property.slug === 'versatile',
+        );
+
+        expect(versatileProperty?.damage).not.toBeNull();
+      }
+    },
+  );
+
+  test(
+    'Weapon simple melee thrown versatile',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.spear.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.name).toBe(expectedEquipmentSamples.spear.name);
+        expect(equipment.details.attackType).toBe(
+          expectedEquipmentSamples.spear.attackType,
+        );
+        expect(equipment.details.versatileDamage).not.toBeNull();
+        expect(equipment.details.range).toBeNull();
+        expect(equipment.details.ammunitionType).toBeNull();
+        expect(equipment.details.proficiencyType).toBe(
+          expectedEquipmentSamples.spear.proficiencyType,
+        );
+        expect(equipment.details.mastery.slug).toBe(
+          expectedEquipmentSamples.spear.masterySlug,
+        );
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.spear.propertySlugs),
+        );
+
+        const thrownProperty = equipment.details.properties.find(
+          (property) => property.slug === 'thrown',
+        );
+        const versatileProperty = equipment.details.properties.find(
+          (property) => property.slug === 'versatile',
+        );
+
+        expect(thrownProperty?.range).toEqual(
+          expectedEquipmentSamples.spear.thrownRange,
+        );
+        expect(versatileProperty?.damage).not.toBeNull();
+      }
+    },
+  );
+
+  test(
+    'Weapon simple ranged ammunition',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.shortbow.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.attackType).toBe(
+          expectedEquipmentSamples.shortbow.attackType,
+        );
+        expect(equipment.details.range).not.toBeNull();
+        expect(equipment.details.ammunitionType).toBe(
+          expectedEquipmentSamples.shortbow.ammunitionType,
+        );
+
+        const ammunitionProperty = equipment.details.properties.find(
+          (property) => property.slug === 'ammunition',
+        );
+
+        expect(ammunitionProperty?.range).not.toBeNull();
+        expect(ammunitionProperty?.ammunitionType).toBe(
+          expectedEquipmentSamples.shortbow.ammunitionType,
+        );
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.shortbow.propertySlugs),
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon simple ranged bullet',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.sling.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.attackType).toBe(
+          expectedEquipmentSamples.sling.attackType,
+        );
+        expect(equipment.details.ammunitionType).toBe(
+          expectedEquipmentSamples.sling.ammunitionType,
+        );
+        expect(equipment.details.damage.damageType).toBe(
+          expectedEquipmentSamples.sling.damageType,
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon martial melee heavy reach two-handed',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.glaive.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.mastery.slug).toBe(
+          expectedEquipmentSamples.glaive.masterySlug,
+        );
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.glaive.propertySlugs),
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon martial melee finesse',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.rapier.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.versatileDamage).toBeNull();
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(expectedEquipmentSamples.rapier.propertySlugs);
+      }
+    },
+  );
+
+  test(
+    'Weapon martial melee conditional two-handed',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.lance.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        const twoHandedProperty = equipment.details.properties.find(
+          (property) => property.slug === 'two-handed',
+        );
+
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.lance.propertySlugs),
+        );
+        expect(twoHandedProperty?.note).toBe(
+          expectedEquipmentSamples.lance.twoHandedNote,
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon martial ranged ammunition loading',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.pistol.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.range).not.toBeNull();
+        expect(equipment.details.ammunitionType).toBe(
+          expectedEquipmentSamples.pistol.ammunitionType,
+        );
+        expect(
+          equipment.details.properties.map((property) => property.slug),
+        ).toEqual(
+          expect.arrayContaining(expectedEquipmentSamples.pistol.propertySlugs),
+        );
+      }
+    },
+  );
+
+  test(
+    'Weapon martial ranged fixed damage',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const { equipment, equipmentAssert } = await getEquipmentDetailBySlug(
+        request,
+        expectedEquipmentSamples.blowgun.slug,
+      );
+
+      if (equipment.details.kind === 'weapon') {
+        await equipmentAssert.validateWeaponDetailsSchema(equipment.details);
+        expect(equipment.details.damage.formula).toBe(
+          expectedEquipmentSamples.blowgun.damageFormula,
+        );
+        expect(equipment.details.damage.dice).toEqual([]);
+        expect(equipment.details.damage.bonus).toBe(
+          expectedEquipmentSamples.blowgun.damageBonus,
+        );
+        expect(equipment.details.ammunitionType).toBe(
+          expectedEquipmentSamples.blowgun.ammunitionType,
+        );
+      }
+    },
+  );
+
+  test(
+    'Armor detail by slug',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const response = await equipmentClient.getEquipmentDetail(
+        expectedEquipmentSamples.chainMail.slug,
+      );
+
+      await equipmentAssert.success(response);
+
+      const equipment: EquipmentDetail = await response.json();
+
+      await equipmentAssert.validateEquipmentDetailSchema(equipment);
+      expect(equipment.details.kind).toBe('armor');
+
+      if (equipment.details.kind === 'armor') {
+        await equipmentAssert.validateArmorDetailsSchema(equipment.details);
+        expect(equipment.name).toBe(expectedEquipmentSamples.chainMail.name);
+        expect(equipment.details.strengthRequirement).toBe(
+          expectedEquipmentSamples.chainMail.strengthRequirement,
+        );
+        expect(equipment.details.stealthDisadvantage).toBe(
+          expectedEquipmentSamples.chainMail.stealthDisadvantage,
+        );
+      }
+    },
+  );
+
+  test(
+    'Shield detail by slug',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const response = await equipmentClient.getEquipmentDetail(
+        expectedEquipmentSamples.shield.slug,
+      );
+
+      await equipmentAssert.success(response);
+
+      const equipment: EquipmentDetail = await response.json();
+
+      await equipmentAssert.validateEquipmentDetailSchema(equipment);
+      expect(equipment.details.kind).toBe('shield');
+
+      if (equipment.details.kind === 'shield') {
+        await equipmentAssert.validateShieldDetailsSchema(equipment.details);
+        expect(equipment.details.trainingType).toBe(
+          expectedEquipmentSamples.shield.trainingType,
+        );
+        expect(equipment.details.armorClassBonus).toBe(
+          expectedEquipmentSamples.shield.armorClassBonus,
+        );
+      }
+    },
+  );
+
+  test(
+    'Generic detail by slug',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const response = await equipmentClient.getEquipmentDetail(
+        expectedEquipmentSamples.thievesTools.slug,
+      );
+
+      await equipmentAssert.success(response);
+
+      const equipment: EquipmentDetail = await response.json();
+
+      await equipmentAssert.validateEquipmentDetailSchema(equipment);
+      expect(equipment.name).toBe(expectedEquipmentSamples.thievesTools.name);
+      expect(equipment.details.kind).toBe('generic');
+
+      if (equipment.details.kind === 'generic') {
+        await equipmentAssert.validateGenericDetailsSchema(equipment.details);
+      }
+    },
+  );
+
+  test(
+    'Lookup by id and by name',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const slugResponse = await equipmentClient.getEquipmentDetail(
+        expectedEquipmentSamples.shield.slug,
+      );
+
+      await equipmentAssert.success(slugResponse);
+
+      const bySlug: EquipmentDetail = await slugResponse.json();
+
+      const idResponse = await equipmentClient.getEquipmentDetail(bySlug.id);
+      await equipmentAssert.success(idResponse);
+      const byId: EquipmentDetail = await idResponse.json();
+
+      const nameResponse = await equipmentClient.getEquipmentDetail(bySlug.name);
+      await equipmentAssert.success(nameResponse);
+      const byName: EquipmentDetail = await nameResponse.json();
+
+      await equipmentAssert.validateEquipmentDetailSchema(bySlug);
+      await equipmentAssert.validateEquipmentDetailSchema(byId);
+      await equipmentAssert.validateEquipmentDetailSchema(byName);
+
+      await test.step('Validate lookup returns the same item for slug, id and name', async () => {
+        expect(byId).toEqual(bySlug);
+        expect(byName).toEqual(bySlug);
+      });
+    },
+  );
+
+  test(
+    'Equipment not found',
+    { tag: ['@get', '@negative', '@error'] },
+    async ({ request }) => {
+      const equipmentClient = new EquipmentClient(request);
+      const equipmentAssert = new EquipmentAssert();
+
+      const response = await equipmentClient.getEquipmentDetail(999999);
+
+      await equipmentAssert.notFound(response);
+
+      const body: { error: string } = await response.json();
+
+      await equipmentAssert.validateErrorResponse(body, 'Equipment not found');
+    },
+  );
+});

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -2,6 +2,7 @@ import {
   CharacterAbilityScoreOptionsResponseBody,
   CharacterAbilityModifiers,
   CharacterAbilityScores,
+  CharacterCurrency,
   CharacterResolvedAbilityScores,
   CharacterClassDetails,
   CharacterListItem,
@@ -55,6 +56,16 @@ export class CharactersAssert {
       INT: this.calculateAbilityModifier(finalAbilityScores.INT),
       WIS: this.calculateAbilityModifier(finalAbilityScores.WIS),
       CHA: this.calculateAbilityModifier(finalAbilityScores.CHA),
+    };
+  }
+
+  private createEmptyCurrency(): CharacterCurrency {
+    return {
+      cp: 0,
+      sp: 0,
+      ep: 0,
+      gp: 0,
+      pp: 0,
     };
   }
 
@@ -323,6 +334,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('missingFields');
       expect(character).toHaveProperty('abilityScores');
       expect(character).toHaveProperty('abilityModifiers');
+      expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
       expect(character).toHaveProperty('classDetails');
@@ -351,6 +363,9 @@ export class CharactersAssert {
       expect(
         character.abilityModifiers === null ||
           typeof character.abilityModifiers === 'object',
+      ).toBe(true);
+      expect(
+        character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
       expect(Array.isArray(character.skillProficiencies)).toBe(true);
       expect(
@@ -392,6 +407,10 @@ export class CharactersAssert {
 
     if (character.abilityModifiers) {
       await this.validateAbilityModifiersSchema(character.abilityModifiers);
+    }
+
+    if (character.currency) {
+      await this.validateCurrencySchema(character.currency);
     }
 
     await test.step(
@@ -602,6 +621,22 @@ export class CharactersAssert {
     });
   }
 
+  async validateCurrencySchema(currency: CharacterCurrency) {
+    await test.step('Validate currency schema', async () => {
+      expect(currency).toHaveProperty('cp');
+      expect(currency).toHaveProperty('sp');
+      expect(currency).toHaveProperty('ep');
+      expect(currency).toHaveProperty('gp');
+      expect(currency).toHaveProperty('pp');
+
+      expect(typeof currency.cp).toBe('number');
+      expect(typeof currency.sp).toBe('number');
+      expect(typeof currency.ep).toBe('number');
+      expect(typeof currency.gp).toBe('number');
+      expect(typeof currency.pp).toBe('number');
+    });
+  }
+
   async validateAbilityScoreRulesSchema(
     abilityScoreRules: CharacterResponseBody['abilityScoreRules'],
   ) {
@@ -765,6 +800,26 @@ export class CharactersAssert {
 
     if (abilityScores) {
       await this.validateResolvedAbilityScoresSchema(abilityScores);
+    }
+  }
+
+  async validateCurrency(
+    currency: CharacterResponseBody['currency'],
+    expectedCurrency: CharacterCurrency | null,
+  ) {
+    await test.step('Validate Currency', async () => {
+      if (expectedCurrency === null) {
+        expect(currency).toBeNull();
+
+        return;
+      }
+
+      expect(currency).not.toBeNull();
+      expect(currency).toEqual(expectedCurrency);
+    });
+
+    if (currency) {
+      await this.validateCurrencySchema(currency);
     }
   }
 

--- a/tests/helpers/equipment.assertions.ts
+++ b/tests/helpers/equipment.assertions.ts
@@ -1,0 +1,149 @@
+import {
+  EquipmentArmorDetails,
+  EquipmentDetail,
+  EquipmentGenericDetails,
+  EquipmentListItem,
+  EquipmentShieldDetails,
+  EquipmentWeaponDetails,
+} from '@/app/types/equipment';
+import { expect, test } from '@playwright/test';
+
+export class EquipmentAssert {
+  async success(response: { status(): number; ok(): boolean }) {
+    await test.step('Should return status code 200', async () => {
+      expect(response.status()).toBe(200);
+      expect(response.ok()).toBeTruthy();
+    });
+  }
+
+  async notFound(response: { status(): number; ok(): boolean }) {
+    await test.step('Should return status code 404', async () => {
+      expect(response.status()).toBe(404);
+      expect(response.ok()).toBeFalsy();
+    });
+  }
+
+  async validateEquipmentListSchema(items: EquipmentListItem[]) {
+    await test.step('Validate equipment list schema', async () => {
+      expect(Array.isArray(items)).toBe(true);
+      expect(items.length).toBeGreaterThan(0);
+    });
+
+    for (const item of items) {
+      await test.step(`Validate equipment list item schema for ${item.name}`, async () => {
+        expect(item).toHaveProperty('id');
+        expect(item).toHaveProperty('name');
+        expect(item).toHaveProperty('category');
+        expect(item).toHaveProperty('type');
+        expect(item).toHaveProperty('cost');
+        expect(item).toHaveProperty('weight');
+        expect(item).toHaveProperty('isMagical');
+
+        expect(typeof item.id).toBe('number');
+        expect(typeof item.name).toBe('string');
+        expect(typeof item.category).toBe('string');
+        expect(typeof item.type).toBe('string');
+        expect(typeof item.cost).toBe('string');
+        expect(item.weight === null || typeof item.weight === 'number').toBe(true);
+        expect(typeof item.isMagical).toBe('boolean');
+      });
+    }
+  }
+
+  async validateEquipmentDetailSchema(item: EquipmentDetail) {
+    await test.step(`Validate equipment detail schema for ${item.name}`, async () => {
+      expect(item).toHaveProperty('id');
+      expect(item).toHaveProperty('name');
+      expect(item).toHaveProperty('slug');
+      expect(item).toHaveProperty('category');
+      expect(item).toHaveProperty('type');
+      expect(item).toHaveProperty('description');
+      expect(item).toHaveProperty('cost');
+      expect(item).toHaveProperty('weight');
+      expect(item).toHaveProperty('isMagical');
+      expect(item).toHaveProperty('modifiers');
+      expect(item).toHaveProperty('effects');
+      expect(item).toHaveProperty('details');
+
+      expect(typeof item.id).toBe('number');
+      expect(typeof item.name).toBe('string');
+      expect(typeof item.slug).toBe('string');
+      expect(typeof item.category).toBe('string');
+      expect(typeof item.type).toBe('string');
+      expect(typeof item.description).toBe('string');
+      expect(typeof item.cost).toBe('string');
+      expect(item.weight === null || typeof item.weight === 'number').toBe(true);
+      expect(typeof item.isMagical).toBe('boolean');
+      expect(Array.isArray(item.modifiers)).toBe(true);
+      expect(Array.isArray(item.effects)).toBe(true);
+      expect(typeof item.details).toBe('object');
+    });
+  }
+
+  async validateWeaponDetailsSchema(details: EquipmentWeaponDetails) {
+    await test.step('Validate weapon details schema', async () => {
+      expect(details.kind).toBe('weapon');
+      expect(typeof details.weaponCategory).toBe('string');
+      expect(typeof details.attackType).toBe('string');
+      expect(typeof details.damage.formula).toBe('string');
+      expect(Array.isArray(details.damage.dice)).toBe(true);
+      expect(typeof details.damage.bonus).toBe('number');
+      expect(typeof details.damage.damageType).toBe('string');
+      expect(details.versatileDamage === null || typeof details.versatileDamage.formula === 'string').toBe(true);
+      expect(Array.isArray(details.properties)).toBe(true);
+      expect(typeof details.mastery.name).toBe('string');
+      expect(typeof details.mastery.slug).toBe('string');
+      expect(details.range === null || typeof details.range.unit === 'string').toBe(true);
+      expect(typeof details.proficiencyType).toBe('string');
+      expect(details.ammunitionType === null || typeof details.ammunitionType === 'string').toBe(true);
+    });
+  }
+
+  async validateArmorDetailsSchema(details: EquipmentArmorDetails) {
+    await test.step('Validate armor details schema', async () => {
+      expect(details.kind).toBe('armor');
+      expect(typeof details.armorType).toBe('string');
+      expect(typeof details.trainingType).toBe('string');
+      expect(typeof details.armorClass.base).toBe('number');
+      expect(typeof details.armorClass.dexModifier.applies).toBe('boolean');
+      expect(
+        details.armorClass.dexModifier.max === null ||
+          typeof details.armorClass.dexModifier.max === 'number',
+      ).toBe(true);
+      expect(
+        details.strengthRequirement === null ||
+          typeof details.strengthRequirement === 'number',
+      ).toBe(true);
+      expect(typeof details.stealthDisadvantage).toBe('boolean');
+      expect(typeof details.donTime).toBe('string');
+      expect(typeof details.doffTime).toBe('string');
+    });
+  }
+
+  async validateShieldDetailsSchema(details: EquipmentShieldDetails) {
+    await test.step('Validate shield details schema', async () => {
+      expect(details.kind).toBe('shield');
+      expect(typeof details.trainingType).toBe('string');
+      expect(typeof details.armorClassBonus).toBe('number');
+      expect(typeof details.donTime).toBe('string');
+      expect(typeof details.doffTime).toBe('string');
+    });
+  }
+
+  async validateGenericDetailsSchema(details: EquipmentGenericDetails) {
+    await test.step('Validate generic details schema', async () => {
+      expect(details.kind).toBe('generic');
+    });
+  }
+
+  async validateErrorResponse(
+    errorResponse: { error: string },
+    expectedError: string,
+  ) {
+    await test.step('Validate error response schema', async () => {
+      expect(errorResponse).toHaveProperty('error');
+      expect(typeof errorResponse.error).toBe('string');
+      expect(errorResponse.error).toBe(expectedError);
+    });
+  }
+}


### PR DESCRIPTION
- implement Equipment API with list and detail endpoints
- add equipment types and detailed schemas for weapons, armor, shields, and generic items
- add shared equipment types and automated coverage for equipment endpoints
- extend character flows with skill proficiencies and ability score rule support
- update character backend helpers, routes, and response types
- expand character API tests and reusable assertions
- refresh OpenAPI documentation and project README
- update homepage and support pages to surface the new API resources