### PR TITLE
feat: add character armor class calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Response fields:
 - `missingFields`
 - `abilityScores`
 - `abilityModifiers`
+- `armorClass`
 - `skillProficiencies`
 - `abilityScoreRules`
 - `classDetails`
@@ -378,6 +379,7 @@ Response fields:
 - `skillProficiencies`
 - `abilityScores`
 - `abilityModifiers`
+- `armorClass`
 - `abilityScoreRules`
 - `classDetails`
 - `speciesDetails`
@@ -388,6 +390,8 @@ Returns:
 - `401` with `{ "error": "Unauthorized" }`
 - `404` with `{ "error": "Character not found" }`
 - `500` with `{ "error": "Failed to fetch character detail" }`
+
+`armorClass` is calculated from the character's resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
 
 ### `PATCH /api/characters/{id}`
 
@@ -706,6 +710,20 @@ Character detail:
     "INT": 3,
     "WIS": 1,
     "CHA": 0
+  },
+  "armorClass": {
+    "total": 12,
+    "base": 10,
+    "dexModifierApplied": 2,
+    "classBonus": 0,
+    "shieldBonus": 0,
+    "sources": [
+      {
+        "name": "Base AC",
+        "type": "base",
+        "value": 10
+      }
+    ]
   },
   "abilityScoreRules": {
     "source": "background",

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, calculated skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -122,6 +122,7 @@ export const apiResources: ApiResource[] = [
       'missingFields',
       'abilityScores',
       'abilityModifiers',
+      'armorClass',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -133,6 +134,7 @@ export const apiResources: ApiResource[] = [
       'status',
       'abilityScores',
       'abilityModifiers',
+      'armorClass',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -168,4 +170,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
+  'Character detail now includes calculated armor class from ability modifiers and equipped gear',
 ];

--- a/app/lib/character-armor-class.ts
+++ b/app/lib/character-armor-class.ts
@@ -1,0 +1,237 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterArmorClass,
+  CharacterArmorClassSource,
+} from '@/app/types/character';
+import { EquipmentArmorDetails, EquipmentShieldDetails } from '@/app/types/equipment';
+import { getSql } from './db';
+
+type EquippedArmorItem = {
+  name: string;
+  details: EquipmentArmorDetails;
+};
+
+type EquippedShieldItem = {
+  name: string;
+  details: EquipmentShieldDetails;
+};
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  return value;
+}
+
+function parseArmorDetails(value: unknown): EquipmentArmorDetails | null {
+  const details = parseJsonValue(value);
+
+  if (typeof details !== 'object' || details === null || Array.isArray(details)) {
+    return null;
+  }
+
+  const armor = details as Record<string, unknown>;
+  const armorClass = armor.armorClass as Record<string, unknown> | undefined;
+  const dexModifier = armorClass?.dexModifier as
+    | Record<string, unknown>
+    | undefined;
+
+  if (
+    armor.kind !== 'armor' ||
+    typeof armor.armorType !== 'string' ||
+    typeof armor.trainingType !== 'string' ||
+    typeof armorClass?.base !== 'number' ||
+    typeof dexModifier?.applies !== 'boolean' ||
+    (dexModifier.max !== null &&
+      dexModifier.max !== undefined &&
+      typeof dexModifier.max !== 'number') ||
+    (armor.strengthRequirement !== null &&
+      armor.strengthRequirement !== undefined &&
+      typeof armor.strengthRequirement !== 'number') ||
+    typeof armor.stealthDisadvantage !== 'boolean' ||
+    typeof armor.donTime !== 'string' ||
+    typeof armor.doffTime !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'armor',
+    armorType: armor.armorType,
+    trainingType: armor.trainingType,
+    armorClass: {
+      base: armorClass.base,
+      dexModifier: {
+        applies: dexModifier.applies,
+        max: dexModifier.max === undefined ? null : (dexModifier.max as number | null),
+      },
+    },
+    strengthRequirement:
+      armor.strengthRequirement === undefined
+        ? null
+        : (armor.strengthRequirement as number | null),
+    stealthDisadvantage: armor.stealthDisadvantage,
+    donTime: armor.donTime,
+    doffTime: armor.doffTime,
+  };
+}
+
+function parseShieldDetails(value: unknown): EquipmentShieldDetails | null {
+  const details = parseJsonValue(value);
+
+  if (typeof details !== 'object' || details === null || Array.isArray(details)) {
+    return null;
+  }
+
+  const shield = details as Record<string, unknown>;
+
+  if (
+    shield.kind !== 'shield' ||
+    typeof shield.trainingType !== 'string' ||
+    typeof shield.armorClassBonus !== 'number' ||
+    typeof shield.donTime !== 'string' ||
+    typeof shield.doffTime !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'shield',
+    trainingType: shield.trainingType,
+    armorClassBonus: shield.armorClassBonus,
+    donTime: shield.donTime,
+    doffTime: shield.doffTime,
+  };
+}
+
+function getDexModifierApplied(
+  dexModifier: number,
+  armor: EquippedArmorItem | null,
+): number {
+  if (!armor) {
+    return dexModifier;
+  }
+
+  const { applies, max } = armor.details.armorClass.dexModifier;
+
+  if (!applies) {
+    return 0;
+  }
+
+  return max === null ? dexModifier : Math.min(dexModifier, max);
+}
+
+function getClassArmorBonus(
+  classSlug: string | null,
+  equippedArmor: EquippedArmorItem | null,
+  equippedShield: EquippedShieldItem | null,
+  abilityModifiers: CharacterAbilityModifiers | null,
+): number {
+  if (equippedArmor) {
+    return 0;
+  }
+
+  if (classSlug === 'barbarian') {
+    return abilityModifiers?.CON ?? 0;
+  }
+
+  if (classSlug === 'monk' && !equippedShield) {
+    return abilityModifiers?.WIS ?? 0;
+  }
+
+  return 0;
+}
+
+export async function getCharacterArmorClass(
+  characterId: number,
+  classDetails: {
+    slug: string;
+  } | null,
+  abilityModifiers: CharacterAbilityModifiers | null,
+): Promise<CharacterArmorClass> {
+  const sql = getSql();
+  const equipmentRows = await sql`
+    SELECT equipment.name, equipment.details
+    FROM characterequipment
+    INNER JOIN equipment ON equipment.id = characterequipment.equipmentid
+    WHERE characterequipment.characterid = ${characterId}
+      AND characterequipment.isequipped = true
+    ORDER BY characterequipment.id
+  `;
+
+  const equippedArmor = equipmentRows.reduce<EquippedArmorItem | null>(
+    (selectedArmor, item) => {
+      if (selectedArmor) {
+        return selectedArmor;
+      }
+
+      const details = parseArmorDetails(item.details);
+
+      return details ? { name: item.name, details } : null;
+    },
+    null,
+  );
+
+  const equippedShield = equipmentRows.reduce<EquippedShieldItem | null>(
+    (selectedShield, item) => {
+      if (selectedShield) {
+        return selectedShield;
+      }
+
+      const details = parseShieldDetails(item.details);
+
+      return details ? { name: item.name, details } : null;
+    },
+    null,
+  );
+
+  const dexModifier = abilityModifiers?.DEX ?? 0;
+  const base = equippedArmor?.details.armorClass.base ?? 10;
+  const dexModifierApplied = getDexModifierApplied(dexModifier, equippedArmor);
+  const classBonus = getClassArmorBonus(
+    classDetails?.slug ?? null,
+    equippedArmor,
+    equippedShield,
+    abilityModifiers,
+  );
+  const shieldBonus = equippedShield?.details.armorClassBonus ?? 0;
+  const sources: CharacterArmorClassSource[] = equippedArmor
+    ? [
+        {
+          name: equippedArmor.name,
+          type: 'armor',
+          value: equippedArmor.details.armorClass.base,
+        },
+      ]
+    : [{ name: 'Base AC', type: 'base', value: 10 }];
+
+  if (equippedShield) {
+    sources.push({
+      name: equippedShield.name,
+      type: 'shield',
+      value: equippedShield.details.armorClassBonus,
+    });
+  }
+
+  if (classBonus !== 0) {
+    sources.push({
+      name: 'Unarmored Defense',
+      type: 'class',
+      value: classBonus,
+    });
+  }
+
+  return {
+    total: base + dexModifierApplied + classBonus + shieldBonus,
+    base,
+    dexModifierApplied,
+    classBonus,
+    shieldBonus,
+    sources,
+  };
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -17,6 +17,7 @@ import { Attributeshortname } from '@/app/types/attribute';
 import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
+import { getCharacterArmorClass } from './character-armor-class';
 import { getSql } from './db';
 
 function toNumber(value: number | string): number {
@@ -601,12 +602,19 @@ export async function formatCharacterResponse(character: {
   const abilityModifiers = getCharacterAbilityModifiers(
     formattedCharacter.abilityScores,
   );
+  const armorClass = await getCharacterArmorClass(
+    formattedCharacter.id,
+    classDetails,
+    abilityModifiers,
+  );
+
   return {
     ...formattedCharacter,
     status: getCharacterStatus(missingFields),
     missingFields,
     abilityScores: formattedCharacter.abilityScores,
     abilityModifiers,
+    armorClass,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -70,6 +70,21 @@ export interface CharacterCurrency {
   pp: number;
 }
 
+export interface CharacterArmorClassSource {
+  name: string;
+  type: 'base' | 'armor' | 'shield' | 'class';
+  value: number;
+}
+
+export interface CharacterArmorClass {
+  total: number;
+  base: number;
+  dexModifierApplied: number;
+  classBonus: number;
+  shieldBonus: number;
+  sources: CharacterArmorClassSource[];
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -141,6 +156,7 @@ export interface CharacterResponseBody {
   missingFields: CharacterMissingField[];
   abilityScores: CharacterResolvedAbilityScores | null;
   abilityModifiers: CharacterAbilityModifiers | null;
+  armorClass: CharacterArmorClass;
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.11.0
+  version: 1.12.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -1061,6 +1061,16 @@ paths:
                   - backgroundId
                 abilityScores: null
                 abilityModifiers: null
+                armorClass:
+                  total: 10
+                  base: 10
+                  dexModifierApplied: 0
+                  classBonus: 0
+                  shieldBonus: 0
+                  sources:
+                    - name: Base AC
+                      type: base
+                      value: 10
                 skillProficiencies: []
                 abilityScoreRules: null
                 classDetails: null
@@ -1103,11 +1113,14 @@ paths:
         When related data exists, the detail payload can include nested:
         - `abilityScores`
         - `abilityModifiers`
+        - `armorClass`
         - `skillProficiencies`
         - `abilityScoreRules`
         - `classDetails`
         - `speciesDetails`
         - `backgroundDetails`
+
+        `armorClass` is calculated from resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
       security:
         - bearerAuth: []
       parameters:
@@ -1160,6 +1173,16 @@ paths:
                   INT: 3
                   WIS: 1
                   CHA: 0
+                armorClass:
+                  total: 12
+                  base: 10
+                  dexModifierApplied: 2
+                  classBonus: 0
+                  shieldBonus: 0
+                  sources:
+                    - name: Base AC
+                      type: base
+                      value: 10
                 abilityScoreRules:
                   source: background
                   allowedChoices:
@@ -3289,6 +3312,65 @@ components:
           type: integer
           example: 0
 
+    CharacterArmorClassSourceType:
+      type: string
+      enum:
+        - base
+        - armor
+        - shield
+        - class
+      example: base
+
+    CharacterArmorClassSource:
+      type: object
+      required:
+        - name
+        - type
+        - value
+      properties:
+        name:
+          type: string
+          example: Base AC
+        type:
+          $ref: '#/components/schemas/CharacterArmorClassSourceType'
+        value:
+          type: integer
+          example: 10
+
+    CharacterArmorClass:
+      type: object
+      required:
+        - total
+        - base
+        - dexModifierApplied
+        - classBonus
+        - shieldBonus
+        - sources
+      properties:
+        total:
+          type: integer
+          example: 12
+        base:
+          type: integer
+          example: 10
+        dexModifierApplied:
+          type: integer
+          example: 2
+        classBonus:
+          type: integer
+          example: 0
+        shieldBonus:
+          type: integer
+          example: 0
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterArmorClassSource'
+          example:
+            - name: Base AC
+              type: base
+              value: 10
+
     CharacterAbilityScoreBonusChoice:
       type: object
       required:
@@ -3570,6 +3652,7 @@ components:
         - missingFields
         - abilityScores
         - abilityModifiers
+        - armorClass
         - skillProficiencies
         - abilityScoreRules
         - classDetails
@@ -3614,6 +3697,8 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityModifiers'
+        armorClass:
+          $ref: '#/components/schemas/CharacterArmorClass'
         skillProficiencies:
           type: array
           items:

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -1,8 +1,10 @@
 import { TokenResponseBody } from '@/app/types/auth';
 import {
   CharacterAbilityScoreOptionsResponseBody,
+  CharacterArmorClass,
   CharacterAbilityScoresInput,
   CharacterAbilityScores,
+  CharacterCreateRequestBody,
   CharacterCurrency,
   CharacterEquipmentResponseBody,
   CharacterSkillItem,
@@ -50,13 +52,22 @@ const paladinAbilityScores: CharacterAbilityScores = {
   CHA: 14,
 };
 
-const patchedDraftAbilityScores: CharacterAbilityScores = {
-  STR: 16,
-  DEX: 12,
+const aangAbilityScores: CharacterAbilityScores = {
+  STR: 10,
+  DEX: 16,
   CON: 14,
-  INT: 10,
-  WIS: 10,
-  CHA: 8,
+  INT: 8,
+  WIS: 15,
+  CHA: 12,
+};
+
+const drizztAbilityScores: CharacterAbilityScores = {
+  STR: 10,
+  DEX: 15,
+  CON: 13,
+  INT: 8,
+  WIS: 14,
+  CHA: 12,
 };
 
 const barbarianAbilityBonuses: CharacterAbilityScores = {
@@ -86,6 +97,24 @@ const paladinAbilityBonuses: CharacterAbilityScores = {
   CHA: 1,
 };
 
+const aangAbilityBonuses: CharacterAbilityScores = {
+  STR: 0,
+  DEX: 0,
+  CON: 0,
+  INT: 1,
+  WIS: 2,
+  CHA: 0,
+};
+
+const drizztAbilityBonuses: CharacterAbilityScores = {
+  STR: 0,
+  DEX: 2,
+  CON: 1,
+  INT: 0,
+  WIS: 0,
+  CHA: 0,
+};
+
 const barbarianAbilityScoresInput: CharacterAbilityScoresInput = {
   base: barbarianAbilityScores,
   bonuses: barbarianAbilityBonuses,
@@ -101,24 +130,14 @@ const paladinAbilityScoresInput: CharacterAbilityScoresInput = {
   bonuses: paladinAbilityBonuses,
 };
 
-const patchedDraftAbilityScoresInput: CharacterAbilityScoresInput = {
-  base: patchedDraftAbilityScores,
-  bonuses: {
-    STR: 0,
-    DEX: 0,
-    CON: 0,
-    INT: 0,
-    WIS: 0,
-    CHA: 0,
-  },
+const aangAbilityScoresInput: CharacterAbilityScoresInput = {
+  base: aangAbilityScores,
+  bonuses: aangAbilityBonuses,
 };
 
-const initialCurrency: CharacterCurrency = {
-  cp: 0,
-  sp: 5,
-  ep: 0,
-  gp: 12,
-  pp: 0,
+const drizztAbilityScoresInput: CharacterAbilityScoresInput = {
+  base: drizztAbilityScores,
+  bonuses: drizztAbilityBonuses,
 };
 
 const patchedCurrency: CharacterCurrency = {
@@ -151,6 +170,59 @@ const nobleCurrency: CharacterCurrency = {
   ep: 0,
   gp: 29,
   pp: 0,
+};
+
+const acolyteCurrency: CharacterCurrency = {
+  cp: 0,
+  sp: 0,
+  ep: 0,
+  gp: 8,
+  pp: 0,
+};
+
+const barbarianArmorClass: CharacterArmorClass = {
+  total: 13,
+  base: 10,
+  dexModifierApplied: 1,
+  classBonus: 2,
+  shieldBonus: 0,
+  sources: [
+    { name: 'Base AC', type: 'base', value: 10 },
+    { name: 'Unarmored Defense', type: 'class', value: 2 },
+  ],
+};
+
+const wizardArmorClass: CharacterArmorClass = {
+  total: 12,
+  base: 10,
+  dexModifierApplied: 2,
+  classBonus: 0,
+  shieldBonus: 0,
+  sources: [{ name: 'Base AC', type: 'base', value: 10 }],
+};
+
+const paladinArmorClass: CharacterArmorClass = {
+  total: 18,
+  base: 16,
+  dexModifierApplied: 0,
+  classBonus: 0,
+  shieldBonus: 2,
+  sources: [
+    { name: 'Chain Mail', type: 'armor', value: 16 },
+    { name: 'Shield', type: 'shield', value: 2 },
+  ],
+};
+
+const aangArmorClass: CharacterArmorClass = {
+  total: 16,
+  base: 10,
+  dexModifierApplied: 3,
+  classBonus: 3,
+  shieldBonus: 0,
+  sources: [
+    { name: 'Base AC', type: 'base', value: 10 },
+    { name: 'Unarmored Defense', type: 'class', value: 3 },
+  ],
 };
 
 const barbarianSkillProficiencies: SkillName[] = [
@@ -225,7 +297,7 @@ async function addCharacterEquipmentBySlug(
 }
 
 test.describe(
-  'Characters API - Barbarian Flow',
+  'Characters API - Conan The Barbarian Full Progression Flow',
   { tag: ['@characters', '@flow', '@barbarian'] },
   () => {
   test.describe.configure({ mode: 'serial' });
@@ -261,7 +333,7 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      createdCharacterName = `Arin ${Date.now()}`;
+      createdCharacterName = `Conan The Barbarian ${Date.now()}`;
 
       const createResponse = await charactersClient.createCharacter(
         {
@@ -484,7 +556,7 @@ test.describe(
   );
 
   test(
-    'Add Species Dwarf',
+    'Add Species Human',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -493,7 +565,7 @@ test.describe(
       const response = await charactersClient.updateCharacter(
         createdCharacterId,
         {
-          speciesId: 2,
+          speciesId: 7,
         },
         authToken,
       );
@@ -504,7 +576,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateClassId(character.classId, 1);
-      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
       await charactersAssert.validateBackgroundId(character.backgroundId, null);
       await charactersAssert.validateMissingFields(character.missingFields, [
         'backgroundId',
@@ -516,10 +588,10 @@ test.describe(
       );
 
       if (character.speciesDetails) {
-        await charactersAssert.validateId(character.speciesDetails.id, 2);
+        await charactersAssert.validateId(character.speciesDetails.id, 7);
         await charactersAssert.validateName(
           character.speciesDetails.name,
-          expectedDetailedSpecies.dwarf.name,
+          expectedDetailedSpecies.human.name,
         );
         await charactersAssert.validateSpeciesDetailsSchema(
           character.speciesDetails,
@@ -529,7 +601,7 @@ test.describe(
   );
 
   test(
-    'Get Dwarf Barbarian',
+    'Get Human Barbarian',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -546,7 +618,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateClassId(character.classId, 1);
-      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
       await charactersAssert.validateBackgroundId(character.backgroundId, null);
       await charactersAssert.validateMissingFields(character.missingFields, [
         'backgroundId',
@@ -590,7 +662,7 @@ test.describe(
       );
       await charactersAssert.validateStatus(updatedCharacter.status, 'complete');
       await charactersAssert.validateClassId(updatedCharacter.classId, 1);
-      await charactersAssert.validateSpeciesId(updatedCharacter.speciesId, 2);
+      await charactersAssert.validateSpeciesId(updatedCharacter.speciesId, 7);
       await charactersAssert.validateBackgroundId(
         updatedCharacter.backgroundId,
         16,
@@ -615,10 +687,10 @@ test.describe(
       );
 
       if (updatedCharacter.speciesDetails) {
-        await charactersAssert.validateId(updatedCharacter.speciesDetails.id, 2);
+        await charactersAssert.validateId(updatedCharacter.speciesDetails.id, 7);
         await charactersAssert.validateName(
           updatedCharacter.speciesDetails.name,
-          expectedDetailedSpecies.dwarf.name,
+          expectedDetailedSpecies.human.name,
         );
         await charactersAssert.validateSpeciesDetailsSchema(
           updatedCharacter.speciesDetails,
@@ -656,7 +728,7 @@ test.describe(
 
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateClassId(character.classId, 1);
-      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
       await charactersAssert.validateBackgroundId(character.backgroundId, 16);
       await charactersAssert.validateMissingFields(character.missingFields, []);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
@@ -693,7 +765,7 @@ test.describe(
       await charactersAssert.validateCharacterResponseSchema(character);
       await charactersAssert.validateId(character.id, createdCharacterId);
       await charactersAssert.validateClassId(character.classId, 1);
-      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
       await charactersAssert.validateBackgroundId(character.backgroundId, 16);
       await charactersAssert.validateStatus(character.status, 'complete');
       await charactersAssert.validateCurrency(character.currency, soldierCurrency);
@@ -1044,7 +1116,7 @@ test.describe(
       await charactersAssert.validateName(finalCharacter.name, createdCharacterName);
       await charactersAssert.validateStatus(finalCharacter.status, 'complete');
       await charactersAssert.validateClassId(finalCharacter.classId, 1);
-      await charactersAssert.validateSpeciesId(finalCharacter.speciesId, 2);
+      await charactersAssert.validateSpeciesId(finalCharacter.speciesId, 7);
       await charactersAssert.validateBackgroundId(finalCharacter.backgroundId, 16);
       await charactersAssert.validateLevel(finalCharacter.level, 1);
       await charactersAssert.validateMissingFields(finalCharacter.missingFields, []);
@@ -1052,6 +1124,10 @@ test.describe(
         finalCharacter.abilityScores,
         barbarianAbilityScores,
         barbarianAbilityBonuses,
+      );
+      await charactersAssert.validateArmorClass(
+        finalCharacter.armorClass,
+        barbarianArmorClass,
       );
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
@@ -1091,10 +1167,10 @@ test.describe(
       }
 
       if (finalCharacter.speciesDetails) {
-        await charactersAssert.validateId(finalCharacter.speciesDetails.id, 2);
+        await charactersAssert.validateId(finalCharacter.speciesDetails.id, 7);
         await charactersAssert.validateName(
           finalCharacter.speciesDetails.name,
-          expectedDetailedSpecies.dwarf.name,
+          expectedDetailedSpecies.human.name,
         );
         await charactersAssert.validateSpeciesDetailsSchema(
           finalCharacter.speciesDetails,
@@ -1117,7 +1193,180 @@ test.describe(
 );
 
 test.describe(
-  'Characters API - Create Complete Paladin',
+  'Characters API - Aang The Monk Unarmored Defense Flow',
+  { tag: ['@characters', '@flow', '@monk'] },
+  () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let authToken: string;
+  let createdCharacterId: number;
+  const createdCharacterName = `Aang The Monk ${Date.now()}`;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Aang The Monk',
+    { tag: ['@post', '@smoke', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: createdCharacterName,
+          classId: 6,
+          speciesId: 7,
+          backgroundId: 1,
+          level: 1,
+          currency: acolyteCurrency,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+      createdCharacterId = character.id;
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateName(character.name, createdCharacterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 6);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateLevel(character.level, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateCurrency(character.currency, acolyteCurrency);
+      await charactersAssert.validateAbilityScoreRules(
+        character.abilityScoreRules,
+        expectedDetailedBackgrounds.acolyte.abilityScores,
+      );
+      await charactersAssert.validateClassDetailsPresence(
+        character.classDetails ?? null,
+        true,
+      );
+      await charactersAssert.validateSpeciesDetailsPresence(
+        character.speciesDetails ?? null,
+        true,
+      );
+      await charactersAssert.validateBackgroundDetailsPresence(
+        character.backgroundDetails ?? null,
+        true,
+      );
+
+      if (character.classDetails) {
+        await charactersAssert.validateName(character.classDetails.name, 'Monk');
+      }
+
+      if (character.speciesDetails) {
+        await charactersAssert.validateName(
+          character.speciesDetails.name,
+          expectedDetailedSpecies.human.name,
+        );
+      }
+
+      if (character.backgroundDetails) {
+        await charactersAssert.validateName(
+          character.backgroundDetails.name,
+          expectedDetailedBackgrounds.acolyte.name,
+        );
+      }
+    },
+  );
+
+  test(
+    'Select Scores Aang',
+    { tag: ['@put', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.updateCharacterAbilityScores(
+        createdCharacterId,
+        {
+          abilityScores: aangAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const abilityScoreOptions = await response.json();
+
+      await charactersAssert.validateCharacterAbilityScoreOptionsSchema(
+        abilityScoreOptions,
+      );
+      await charactersAssert.validateSelectedAbilityScores(
+        abilityScoreOptions.selectedAbilityScores,
+        aangAbilityScores,
+        aangAbilityBonuses,
+      );
+    },
+  );
+
+  test(
+    'Add Quarterstaff Aang',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const characterEquipment = await addCharacterEquipmentBySlug(
+        request,
+        createdCharacterId,
+        authToken,
+        [{ slug: 'quarterstaff', quantity: 1, isEquipped: true }],
+      );
+      const charactersAssert = new CharactersAssert();
+
+      await charactersAssert.validateCharacterEquipmentSchema(characterEquipment);
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Quarterstaff', quantity: 1, isEquipped: true },
+      ]);
+    },
+  );
+
+  test(
+    'Get Complete Aang The Monk',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateName(character.name, createdCharacterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 6);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        aangAbilityScores,
+        aangAbilityBonuses,
+      );
+      await charactersAssert.validateCurrency(character.currency, acolyteCurrency);
+      await charactersAssert.validateArmorClass(
+        character.armorClass,
+        aangArmorClass,
+      );
+    },
+  );
+  },
+);
+
+test.describe(
+  'Characters API - Arthas The Paladin Complete Create Flow',
   { tag: ['@characters', '@flow', '@complete-create'] },
   () => {
   test.describe.configure({ mode: 'serial' });
@@ -1132,12 +1381,12 @@ test.describe(
   });
 
   test(
-    'Create Paladin Human Noble',
+    'Create Arthas The Paladin',
     { tag: ['@post', '@smoke', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      createdCharacterName = `Cedric ${Date.now()}`;
+      createdCharacterName = `Arthas The Paladin ${Date.now()}`;
 
       const response = await charactersClient.createCharacter(
         {
@@ -1221,7 +1470,7 @@ test.describe(
   );
 
   test(
-    'Get Paladin',
+    'Get Arthas The Paladin',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -1587,7 +1836,7 @@ test.describe(
   );
 
   test(
-    'Get Complete Paladin',
+    'Get Complete Arthas The Paladin',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -1615,6 +1864,10 @@ test.describe(
         character.abilityScores,
         paladinAbilityScores,
         paladinAbilityBonuses,
+      );
+      await charactersAssert.validateArmorClass(
+        character.armorClass,
+        paladinArmorClass,
       );
       await charactersAssert.validateCurrency(character.currency, nobleCurrency);
       await charactersAssert.validateAbilityScoreRules(
@@ -1670,7 +1923,7 @@ test.describe(
 );
 
 test.describe(
-  'Characters API - Wizard Flow',
+  'Characters API - Gandalf The Wizard Spell Selection Flow',
   { tag: ['@characters', '@flow', '@wizard'] },
   () => {
   test.describe.configure({ mode: 'serial' });
@@ -1702,12 +1955,12 @@ test.describe(
   );
 
   test(
-    'Create Draft',
+    'Create Gandalf The Wizard',
     { tag: ['@post', '@smoke', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      createdCharacterName = `Merien ${Date.now()}`;
+      createdCharacterName = `Gandalf The Wizard ${Date.now()}`;
 
       const createResponse = await charactersClient.createCharacter(
         {
@@ -1821,7 +2074,7 @@ test.describe(
   );
 
   test(
-    'Add Class Wizard',
+    'Add Class Wizard To Gandalf',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -1890,7 +2143,7 @@ test.describe(
   );
 
   test(
-    'Get Wizard',
+    'Get Gandalf The Wizard',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2571,7 +2824,7 @@ test.describe(
   );
 
   test(
-    'Get Complete Wizard',
+    'Get Complete Gandalf The Wizard',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2599,6 +2852,10 @@ test.describe(
         finalCharacter.abilityScores,
         wizardAbilityScores,
         wizardAbilityBonuses,
+      );
+      await charactersAssert.validateArmorClass(
+        finalCharacter.armorClass,
+        wizardArmorClass,
       );
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
@@ -2664,8 +2921,8 @@ test.describe(
 );
 
 test.describe(
-  'Characters API - Ability Scores And Currency',
-  { tag: ['@characters', '@ability-scores', '@currency'] },
+  'Characters API - Drizzt The Ranger Ability Scores And Currency Flow',
+  { tag: ['@characters', '@ranger', '@ability-scores', '@currency'] },
   () => {
   test.describe.configure({ mode: 'serial' });
 
@@ -2681,17 +2938,38 @@ test.describe(
     authToken = await issueDemoToken(request);
   });
 
+  const buildDrizztRangerPayload = (
+    name: string,
+    payload: Partial<Omit<CharacterCreateRequestBody, 'name'>> = {},
+  ): CharacterCreateRequestBody => ({
+    name,
+    classId: 8,
+    speciesId: 3,
+    backgroundId: 16,
+    level: 1,
+    ...payload,
+  });
+
+  async function validateDrizztRangerBuild(character: CharacterResponseBody) {
+    await test.step('Validate Drizzt Ranger build', async () => {
+      expect(character.classId).toBe(8);
+      expect(character.speciesId).toBe(3);
+      expect(character.backgroundId).toBe(16);
+      expect(character.missingFields).toEqual([]);
+    });
+  }
+
   test(
-    'Create No Scores',
+    'Create Drizzt Without Scores',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `No Scores ${Date.now()}`,
-        },
+        buildDrizztRangerPayload(
+          `Drizzt The Ranger Without Scores ${Date.now()}`,
+        ),
         authToken,
       );
 
@@ -2701,14 +2979,15 @@ test.describe(
       noScoresCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get No Scores',
+    'Get Drizzt Without Scores',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2724,24 +3003,24 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Create With Scores',
+    'Create Drizzt With Scores',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `With Scores ${Date.now()}`,
-          abilityScores: patchedDraftAbilityScoresInput,
-        },
+        buildDrizztRangerPayload(`Drizzt The Ranger With Scores ${Date.now()}`, {
+          abilityScores: drizztAbilityScoresInput,
+        }),
         authToken,
       );
 
@@ -2751,17 +3030,19 @@ test.describe(
       withScoresCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
-        patchedDraftAbilityScores,
+        drizztAbilityScores,
+        drizztAbilityBonuses,
       );
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get With Scores',
+    'Get Drizzt With Scores',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2777,26 +3058,26 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
-        patchedDraftAbilityScores,
+        drizztAbilityScores,
+        drizztAbilityBonuses,
       );
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Patch Scores',
+    'Patch Scores Drizzt',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Patch Scores ${Date.now()}`,
-        },
+        buildDrizztRangerPayload(`Drizzt The Ranger Patch Scores ${Date.now()}`),
         authToken,
       );
 
@@ -2808,7 +3089,7 @@ test.describe(
       const response = await charactersClient.updateCharacter(
         patchScoresCharacterId,
         {
-          abilityScores: patchedDraftAbilityScoresInput,
+          abilityScores: drizztAbilityScoresInput,
         },
         authToken,
       );
@@ -2818,17 +3099,19 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
-        patchedDraftAbilityScores,
+        drizztAbilityScores,
+        drizztAbilityBonuses,
       );
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get Patched Scores',
+    'Get Patched Scores Drizzt',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2844,17 +3127,19 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
-        patchedDraftAbilityScores,
+        drizztAbilityScores,
+        drizztAbilityBonuses,
       );
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Clear Scores',
+    'Clear Scores Drizzt',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2873,14 +3158,15 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get Cleared Scores',
+    'Get Cleared Scores Drizzt',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2896,23 +3182,24 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Create No Currency',
+    'Create Drizzt Without Currency',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `No Currency ${Date.now()}`,
-        },
+        buildDrizztRangerPayload(
+          `Drizzt The Ranger Without Currency ${Date.now()}`,
+        ),
         authToken,
       );
 
@@ -2922,13 +3209,14 @@ test.describe(
       noCurrencyCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get No Currency',
+    'Get Drizzt Without Currency',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2944,23 +3232,23 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Create With Currency',
+    'Create Drizzt With Currency',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `With Currency ${Date.now()}`,
-          currency: initialCurrency,
-        },
+        buildDrizztRangerPayload(`Drizzt The Ranger With Currency ${Date.now()}`, {
+          currency: soldierCurrency,
+        }),
         authToken,
       );
 
@@ -2970,13 +3258,14 @@ test.describe(
       withCurrencyCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateCurrency(character.currency, initialCurrency);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await validateDrizztRangerBuild(character);
+      await charactersAssert.validateCurrency(character.currency, soldierCurrency);
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get With Currency',
+    'Get Drizzt With Currency',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -2992,22 +3281,21 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateCurrency(character.currency, initialCurrency);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await validateDrizztRangerBuild(character);
+      await charactersAssert.validateCurrency(character.currency, soldierCurrency);
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Patch Currency',
+    'Patch Currency Drizzt',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Patch Currency ${Date.now()}`,
-        },
+        buildDrizztRangerPayload(`Drizzt The Ranger Patch Currency ${Date.now()}`),
         authToken,
       );
 
@@ -3029,13 +3317,14 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, patchedCurrency);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get Patched Currency',
+    'Get Patched Currency Drizzt',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3051,13 +3340,14 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, patchedCurrency);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Clear Currency',
+    'Clear Currency Drizzt',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3076,13 +3366,14 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Get Cleared Currency',
+    'Get Cleared Currency Drizzt',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3098,37 +3389,38 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
   },
 );
 
 test.describe(
-  'Characters API - Equipment',
-  { tag: ['@characters', '@equipment'] },
+  'Characters API - Gimli The Fighter Equipment Flow',
+  { tag: ['@characters', '@equipment', '@fighter', '@dwarf'] },
   () => {
   test.describe.configure({ mode: 'serial' });
 
   let authToken: string;
   let characterWithoutEquipmentId: number;
   let characterWithEquipmentId: number;
-  let longswordEquipmentId: number;
+  let greataxeEquipmentId: number;
 
   test.beforeAll(async ({ request }) => {
     authToken = await issueDemoToken(request);
 
     const equipmentClient = new EquipmentClient(request);
-    const equipmentResponse = await equipmentClient.getEquipmentDetail('longsword');
+    const equipmentResponse = await equipmentClient.getEquipmentDetail('greataxe');
     expect(equipmentResponse.status()).toBe(200);
     const equipment: EquipmentDetail = await equipmentResponse.json();
-    expect(equipment.name).toBe('Longsword');
-    longswordEquipmentId = equipment.id;
+    expect(equipment.name).toBe('Greataxe');
+    greataxeEquipmentId = equipment.id;
   });
 
   test(
-    'Create Character Without Equipment',
+    'Create Gimli Without Equipment',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3136,7 +3428,11 @@ test.describe(
 
       const response = await charactersClient.createCharacter(
         {
-          name: `No Equipment ${Date.now()}`,
+          name: `Gimli The Fighter Without Equipment ${Date.now()}`,
+          classId: 5,
+          speciesId: 2,
+          backgroundId: 16,
+          level: 1,
         },
         authToken,
       );
@@ -3147,7 +3443,10 @@ test.describe(
       characterWithoutEquipmentId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateClassId(character.classId, 5);
+      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 16);
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
@@ -3181,7 +3480,7 @@ test.describe(
   );
 
   test(
-    'Create Character With Equipment',
+    'Create Gimli The Fighter',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3189,7 +3488,11 @@ test.describe(
 
       const response = await charactersClient.createCharacter(
         {
-          name: `With Equipment ${Date.now()}`,
+          name: `Gimli The Fighter ${Date.now()}`,
+          classId: 5,
+          speciesId: 2,
+          backgroundId: 16,
+          level: 1,
         },
         authToken,
       );
@@ -3200,31 +3503,29 @@ test.describe(
       characterWithEquipmentId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateStatus(character.status, 'draft');
+      await charactersAssert.validateClassId(character.classId, 5);
+      await charactersAssert.validateSpeciesId(character.speciesId, 2);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 16);
+      await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
 
   test(
-    'Add Longsword Equipment',
+    'Add Gimli Equipment',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
-      const response = await charactersClient.addCharacterEquipment(
+      const characterEquipment = await addCharacterEquipmentBySlug(
+        request,
         characterWithEquipmentId,
-        {
-          equipmentId: longswordEquipmentId,
-          quantity: 1,
-          isEquipped: true,
-        },
         authToken,
+        [
+          { slug: 'greataxe', quantity: 1, isEquipped: true },
+          { slug: 'chain-mail', quantity: 1, isEquipped: true },
+          { slug: 'shield', quantity: 1, isEquipped: true },
+        ],
       );
-
-      await charactersAssert.created(response);
-
-      const characterEquipment: CharacterEquipmentResponseBody =
-        await response.json();
 
       await charactersAssert.validateCharacterEquipmentSchema(characterEquipment);
       await charactersAssert.validateId(
@@ -3232,16 +3533,21 @@ test.describe(
         characterWithEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItem(characterEquipment, {
-        id: longswordEquipmentId,
-        name: 'Longsword',
+        id: greataxeEquipmentId,
+        name: 'Greataxe',
         quantity: 1,
         isEquipped: true,
       });
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Greataxe', quantity: 1, isEquipped: true },
+        { name: 'Chain Mail', quantity: 1, isEquipped: true },
+        { name: 'Shield', quantity: 1, isEquipped: true },
+      ]);
     },
   );
 
   test(
-    'Get Added Equipment',
+    'Get Gimli Equipment',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3263,15 +3569,20 @@ test.describe(
         characterWithEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItem(characterEquipment, {
-        id: longswordEquipmentId,
+        id: greataxeEquipmentId,
         quantity: 1,
         isEquipped: true,
       });
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Greataxe', quantity: 1, isEquipped: true },
+        { name: 'Chain Mail', quantity: 1, isEquipped: true },
+        { name: 'Shield', quantity: 1, isEquipped: true },
+      ]);
     },
   );
 
   test(
-    'Add Longsword Again',
+    'Add Greataxe Again',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3280,7 +3591,7 @@ test.describe(
       const response = await charactersClient.addCharacterEquipment(
         characterWithEquipmentId,
         {
-          equipmentId: longswordEquipmentId,
+          equipmentId: greataxeEquipmentId,
           quantity: 2,
           isEquipped: false,
         },
@@ -3298,15 +3609,19 @@ test.describe(
         characterWithEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItem(characterEquipment, {
-        id: longswordEquipmentId,
+        id: greataxeEquipmentId,
         quantity: 3,
         isEquipped: false,
       });
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Chain Mail', quantity: 1, isEquipped: true },
+        { name: 'Shield', quantity: 1, isEquipped: true },
+      ]);
     },
   );
 
   test(
-    'Patch Longsword Equipment',
+    'Patch Greataxe Equipment',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3314,7 +3629,7 @@ test.describe(
 
       const response = await charactersClient.patchCharacterEquipment(
         characterWithEquipmentId,
-        longswordEquipmentId,
+        greataxeEquipmentId,
         {
           quantity: 2,
           isEquipped: false,
@@ -3333,7 +3648,7 @@ test.describe(
         characterWithEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItem(characterEquipment, {
-        id: longswordEquipmentId,
+        id: greataxeEquipmentId,
         quantity: 2,
         isEquipped: false,
       });
@@ -3341,7 +3656,7 @@ test.describe(
   );
 
   test(
-    'Patch Longsword Equipped',
+    'Patch Greataxe Equipped',
     { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3349,7 +3664,7 @@ test.describe(
 
       const response = await charactersClient.patchCharacterEquipment(
         characterWithEquipmentId,
-        longswordEquipmentId,
+        greataxeEquipmentId,
         {
           isEquipped: true,
         },
@@ -3367,7 +3682,7 @@ test.describe(
         characterWithEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItem(characterEquipment, {
-        id: longswordEquipmentId,
+        id: greataxeEquipmentId,
         quantity: 2,
         isEquipped: true,
       });
@@ -3375,7 +3690,7 @@ test.describe(
   );
 
   test(
-    'Delete Longsword Equipment',
+    'Delete Greataxe Equipment',
     { tag: ['@delete', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3383,7 +3698,7 @@ test.describe(
 
       const response = await charactersClient.deleteCharacterEquipment(
         characterWithEquipmentId,
-        longswordEquipmentId,
+        greataxeEquipmentId,
         authToken,
       );
 
@@ -3399,13 +3714,17 @@ test.describe(
       );
       await charactersAssert.validateCharacterEquipmentItemAbsent(
         characterEquipment,
-        longswordEquipmentId,
+        greataxeEquipmentId,
       );
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Chain Mail', quantity: 1, isEquipped: true },
+        { name: 'Shield', quantity: 1, isEquipped: true },
+      ]);
     },
   );
 
   test(
-    'Get Deleted Equipment',
+    'Get Equipment Without Greataxe',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3428,16 +3747,20 @@ test.describe(
       );
       await charactersAssert.validateCharacterEquipmentItemAbsent(
         characterEquipment,
-        longswordEquipmentId,
+        greataxeEquipmentId,
       );
+      await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Chain Mail', quantity: 1, isEquipped: true },
+        { name: 'Shield', quantity: 1, isEquipped: true },
+      ]);
     },
   );
   },
 );
 
 test.describe(
-  'Characters API - Delete Flow',
-  { tag: ['@characters', '@flow', '@delete'] },
+  'Characters API - Bilbo The Rogue Delete Flow',
+  { tag: ['@characters', '@flow', '@delete', '@rogue'] },
   () => {
   test.describe.configure({ mode: 'serial' });
 
@@ -3450,18 +3773,18 @@ test.describe(
   });
 
   test(
-    'Create Rogue Orc Criminal',
+    'Create Bilbo The Rogue For Delete',
     { tag: ['@post', '@smoke', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      createdCharacterName = `Shade ${Date.now()}`;
+      createdCharacterName = `Bilbo The Rogue ${Date.now()}`;
 
       const response = await charactersClient.createCharacter(
         {
           name: createdCharacterName,
           classId: 9,
-          speciesId: 8,
+          speciesId: 7,
           backgroundId: 5,
           level: 1,
         },
@@ -3478,7 +3801,7 @@ test.describe(
       await charactersAssert.validateName(character.name, createdCharacterName);
       await charactersAssert.validateStatus(character.status, 'complete');
       await charactersAssert.validateClassId(character.classId, 9);
-      await charactersAssert.validateSpeciesId(character.speciesId, 8);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
       await charactersAssert.validateBackgroundId(character.backgroundId, 5);
       await charactersAssert.validateLevel(character.level, 1);
       await charactersAssert.validateMissingFields(character.missingFields, []);
@@ -3486,7 +3809,7 @@ test.describe(
   );
 
   test(
-    'Delete Rogue Orc Criminal',
+    'Delete Bilbo The Rogue',
     { tag: ['@delete', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3509,7 +3832,7 @@ test.describe(
   );
 
   test(
-    'Get Deleted Character',
+    'Get Deleted Bilbo Returns Not Found',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3529,7 +3852,7 @@ test.describe(
   );
 
   test(
-    'List Without Deleted Character',
+    'List Excludes Deleted Bilbo',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3552,19 +3875,31 @@ test.describe(
 );
 
 test.describe(
-  'Characters API - Negative',
-  { tag: ['@characters', '@negative'] },
+  'Characters API - Geralt Of Rivia The Warlock Negative Flow',
+  { tag: ['@characters', '@negative', '@warlock', '@dragonborn'] },
   () => {
+  const buildGeraltWarlockPayload = (
+    name: string,
+    payload: Partial<Omit<CharacterCreateRequestBody, 'name'>> = {},
+  ): CharacterCreateRequestBody => ({
+    name,
+    classId: 11,
+    speciesId: 1,
+    backgroundId: 1,
+    level: 1,
+    ...payload,
+  });
+
   test(
-    'Create character without token',
+    'Create Geralt Without Token Is Unauthorized',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
-      const response = await charactersClient.createCharacter({
-        name: 'Unauthorized Character',
-      });
+      const response = await charactersClient.createCharacter(
+        buildGeraltWarlockPayload('Geralt Of Rivia Unauthorized'),
+      );
 
       await charactersAssert.unauthorized(response);
 
@@ -3575,7 +3910,7 @@ test.describe(
   );
 
   test(
-    'Get character without token',
+    'Get Character Without Token Is Unauthorized',
     { tag: ['@get', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3592,13 +3927,13 @@ test.describe(
   );
 
   test(
-    'Patch character without token',
+    'Patch Character Without Token Is Unauthorized',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
-      const response = await charactersClient.updateCharacter(1, { classId: 1 });
+      const response = await charactersClient.updateCharacter(1, { classId: 11 });
 
       await charactersAssert.unauthorized(response);
 
@@ -3609,7 +3944,7 @@ test.describe(
   );
 
   test(
-    'Delete character without token',
+    'Delete Character Without Token Is Unauthorized',
     { tag: ['@delete', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3626,7 +3961,7 @@ test.describe(
   );
 
   test(
-    'Get character equipment without token',
+    'Get Character Equipment Without Token Is Unauthorized',
     { tag: ['@get', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3643,7 +3978,7 @@ test.describe(
   );
 
   test(
-    'Add character equipment without token',
+    'Add Character Equipment Without Token Is Unauthorized',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3664,7 +3999,7 @@ test.describe(
   );
 
   test(
-    'Patch character equipment without token',
+    'Patch Character Equipment Without Token Is Unauthorized',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3683,7 +4018,7 @@ test.describe(
   );
 
   test(
-    'Delete character equipment without token',
+    'Delete Character Equipment Without Token Is Unauthorized',
     { tag: ['@delete', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3700,7 +4035,7 @@ test.describe(
   );
 
   test(
-    'Get non-existent character',
+    'Get Non-Existent Character Returns Not Found',
     { tag: ['@get', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3718,7 +4053,7 @@ test.describe(
   );
 
   test(
-    'Patch non-existent character',
+    'Patch Non-Existent Character Returns Not Found',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3727,7 +4062,7 @@ test.describe(
 
       const response = await charactersClient.updateCharacter(
         999999,
-        { classId: 1 },
+        { classId: 11 },
         token,
       );
 
@@ -3740,7 +4075,7 @@ test.describe(
   );
 
   test(
-    'Delete non-existent character',
+    'Delete Non-Existent Character Returns Not Found',
     { tag: ['@delete', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3758,7 +4093,7 @@ test.describe(
   );
 
   test(
-    'Get non-existent character equipment',
+    'Get Non-Existent Character Equipment Returns Not Found',
     { tag: ['@get', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3776,7 +4111,7 @@ test.describe(
   );
 
   test(
-    'Add equipment to non-existent character',
+    'Add Equipment To Non-Existent Character Returns Not Found',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3802,7 +4137,7 @@ test.describe(
   );
 
   test(
-    'Patch equipment on non-existent character',
+    'Patch Equipment On Non-Existent Character Returns Not Found',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3827,7 +4162,7 @@ test.describe(
   );
 
   test(
-    'Delete equipment on non-existent character',
+    'Delete Equipment On Non-Existent Character Returns Not Found',
     { tag: ['@delete', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3849,7 +4184,7 @@ test.describe(
   );
 
   test(
-    'Add non-existent equipment to character',
+    'Add Non-Existent Equipment To Geralt Returns Not Found',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3857,9 +4192,9 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Invalid Equipment ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(
+          `Geralt Of Rivia Invalid Equipment ${Date.now()}`,
+        ),
         token,
       );
 
@@ -3886,7 +4221,7 @@ test.describe(
   );
 
   test(
-    'Patch missing character equipment',
+    'Patch Missing Geralt Equipment Returns Not Found',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3894,9 +4229,9 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Missing Equipment Patch ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(
+          `Geralt Of Rivia Missing Equipment Patch ${Date.now()}`,
+        ),
         token,
       );
 
@@ -3925,7 +4260,7 @@ test.describe(
   );
 
   test(
-    'Delete missing character equipment',
+    'Delete Missing Geralt Equipment Returns Not Found',
     { tag: ['@delete', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3933,9 +4268,9 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Missing Equipment Delete ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(
+          `Geralt Of Rivia Missing Equipment Delete ${Date.now()}`,
+        ),
         token,
       );
 
@@ -3961,7 +4296,7 @@ test.describe(
   );
 
   test(
-    'Add character equipment with invalid payload',
+    'Add Geralt Equipment With Invalid Payload',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -3969,9 +4304,9 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Invalid Equipment Payload ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(
+          `Geralt Of Rivia Invalid Equipment Payload ${Date.now()}`,
+        ),
         token,
       );
 
@@ -4001,7 +4336,7 @@ test.describe(
   );
 
   test(
-    'Patch character equipment with invalid quantity',
+    'Patch Character Equipment With Invalid Quantity',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4029,7 +4364,7 @@ test.describe(
   );
 
   test(
-    'Patch character equipment with empty payload',
+    'Patch Character Equipment With Empty Payload',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4055,7 +4390,7 @@ test.describe(
   );
 
   test(
-    'Patch character equipment with non-numeric quantity',
+    'Patch Character Equipment With Non-Numeric Quantity',
     { tag: ['@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4083,7 +4418,7 @@ test.describe(
   );
 
   test(
-    'Create character with invalid payload',
+    'Create Geralt With Invalid Payload',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4093,6 +4428,10 @@ test.describe(
       const response = await charactersClient.createCharacter(
         {
           name: '',
+          classId: 11,
+          speciesId: 1,
+          backgroundId: 1,
+          level: 1,
         },
         token,
       );
@@ -4109,7 +4448,7 @@ test.describe(
   );
 
   test(
-    'Patch character with invalid payload',
+    'Patch Geralt With Invalid Payload',
     { tag: ['@post', '@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4117,9 +4456,7 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Invalid Patch ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Patch ${Date.now()}`),
         token,
       );
 
@@ -4147,7 +4484,7 @@ test.describe(
   );
 
   test(
-    'Create character with incomplete scores',
+    'Create Geralt With Incomplete Scores',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4155,8 +4492,7 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `Incomplete Scores ${Date.now()}`,
+        buildGeraltWarlockPayload(`Geralt Of Rivia Incomplete Scores ${Date.now()}`, {
           abilityScores: {
             base: {
               STR: 15,
@@ -4165,7 +4501,7 @@ test.describe(
               STR: 2,
             },
           } as unknown as CharacterAbilityScoresInput,
-        },
+        }),
         token,
       );
 
@@ -4181,7 +4517,7 @@ test.describe(
   );
 
   test(
-    'Patch character with non-numeric score',
+    'Patch Geralt With Non-Numeric Score',
     { tag: ['@post', '@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4189,9 +4525,7 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Invalid Scores ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Scores ${Date.now()}`),
         token,
       );
 
@@ -4236,7 +4570,7 @@ test.describe(
   );
 
   test(
-    'Create character with incomplete currency',
+    'Create Geralt With Incomplete Currency',
     { tag: ['@post', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4244,12 +4578,14 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const response = await charactersClient.createCharacter(
-        {
-          name: `Incomplete Currency ${Date.now()}`,
+        buildGeraltWarlockPayload(
+          `Geralt Of Rivia Incomplete Currency ${Date.now()}`,
+          {
           currency: {
             gp: 10,
           } as unknown as CharacterCurrency,
-        },
+          },
+        ),
         token,
       );
 
@@ -4265,7 +4601,7 @@ test.describe(
   );
 
   test(
-    'Patch character with non-numeric currency',
+    'Patch Geralt With Non-Numeric Currency',
     { tag: ['@post', '@patch', '@negative', '@error'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
@@ -4273,9 +4609,7 @@ test.describe(
       const token = await issueDemoToken(request);
 
       const createResponse = await charactersClient.createCharacter(
-        {
-          name: `Invalid Currency ${Date.now()}`,
-        },
+        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Currency ${Date.now()}`),
         token,
       );
 

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -1,6 +1,7 @@
 import {
   CharacterAbilityScoreOptionsResponseBody,
   CharacterAbilityModifiers,
+  CharacterArmorClass,
   CharacterAbilityScores,
   CharacterCurrency,
   CharacterResolvedAbilityScores,
@@ -413,6 +414,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('missingFields');
       expect(character).toHaveProperty('abilityScores');
       expect(character).toHaveProperty('abilityModifiers');
+      expect(character).toHaveProperty('armorClass');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -443,6 +445,7 @@ export class CharactersAssert {
         character.abilityModifiers === null ||
           typeof character.abilityModifiers === 'object',
       ).toBe(true);
+      expect(typeof character.armorClass).toBe('object');
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -487,6 +490,8 @@ export class CharactersAssert {
     if (character.abilityModifiers) {
       await this.validateAbilityModifiersSchema(character.abilityModifiers);
     }
+
+    await this.validateArmorClassSchema(character.armorClass);
 
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
@@ -698,6 +703,47 @@ export class CharactersAssert {
       expect(typeof abilityModifiers.WIS).toBe('number');
       expect(typeof abilityModifiers.CHA).toBe('number');
     });
+  }
+
+  async validateArmorClassSchema(armorClass: CharacterArmorClass) {
+    await test.step('Validate armor class schema', async () => {
+      expect(armorClass).toHaveProperty('total');
+      expect(armorClass).toHaveProperty('base');
+      expect(armorClass).toHaveProperty('dexModifierApplied');
+      expect(armorClass).toHaveProperty('classBonus');
+      expect(armorClass).toHaveProperty('shieldBonus');
+      expect(armorClass).toHaveProperty('sources');
+
+      expect(typeof armorClass.total).toBe('number');
+      expect(typeof armorClass.base).toBe('number');
+      expect(typeof armorClass.dexModifierApplied).toBe('number');
+      expect(typeof armorClass.classBonus).toBe('number');
+      expect(typeof armorClass.shieldBonus).toBe('number');
+      expect(Array.isArray(armorClass.sources)).toBe(true);
+    });
+
+    for (const source of armorClass.sources) {
+      await test.step(`Validate armor class source schema for ${source.name}`, async () => {
+        expect(source).toHaveProperty('name');
+        expect(source).toHaveProperty('type');
+        expect(source).toHaveProperty('value');
+
+        expect(typeof source.name).toBe('string');
+        expect(['base', 'armor', 'shield', 'class']).toContain(source.type);
+        expect(typeof source.value).toBe('number');
+      });
+    }
+  }
+
+  async validateArmorClass(
+    armorClass: CharacterArmorClass,
+    expectedArmorClass: CharacterArmorClass,
+  ) {
+    await test.step('Validate Armor Class', async () => {
+      expect(armorClass).toEqual(expectedArmorClass);
+    });
+
+    await this.validateArmorClassSchema(armorClass);
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR adds `armorClass` calculation to character detail responses.

The calculation uses the character’s ability modifiers and equipped equipment, and also includes class-specific unarmored AC support for Monk and Barbarian.

## What Changed

- added `armorClass` to `GET /api/characters/[id]`
- calculated unarmored AC when no armor is equipped
- calculated armor AC from equipped armor details
- applied shield bonus when a shield is equipped
- ignored inventory equipment when `isEquipped` is `false`
- added class-specific unarmored AC support for Monk
- added class-specific unarmored AC support for Barbarian
- added source details to explain how AC was calculated
- updated character tests with named famous character scenarios
- expanded automated coverage for armor, shield, and unarmored AC cases

## API Behavior

The character detail response now includes an `armorClass` block.

Example:

```json
{
  "armorClass": {
    "total": 18,
    "base": 16,
    "dexModifierApplied": 0,
    "shieldBonus": 2,
    "sources": [
      {
        "name": "Chain Mail",
        "type": "armor",
        "value": 16
      },
      {
        "name": "Shield",
        "type": "shield",
        "value": 2
      }
    ]
  }
}
```

## Calculation Rules

This PR supports the following initial rules:

- equipment only contributes to AC when `isEquipped` is `true`
- equipment in inventory with `isEquipped: false` does not affect AC
- if armor is equipped, the armor detail is used as the AC base
- if no armor is equipped, base AC uses unarmored rules
- shield bonus is applied when a shield is equipped
- Monk unarmored AC is supported
- Barbarian unarmored AC is supported
- the response includes calculation sources for transparency

## Why

The character sheet already supports:
- ability scores
- ability modifiers
- equipment
- equipped state

Adding `armorClass` makes the character detail much more useful and prepares the API for future combat-related features.

## Testing

This PR includes coverage for:
- unarmored AC
- equipped armor AC
- equipped shield bonus
- ignoring unequipped equipment
- Monk unarmored AC
- Barbarian unarmored AC
- named famous character scenarios for clearer test intent

## Notes

This PR focuses only on armor class calculation.

It does not yet include:
- weapon attacks
- hit points
- conditions
- temporary bonuses
- magical item bonuses
- encumbrance or inventory weight