### PR TITLE
39 add weapon attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Request body fields:
 - `backgroundId` optional
 - `level` optional, defaults to `1`
 - `abilityScores` optional
+- `currency` optional
 - `skillProficiencies` optional
 
 Response fields:
@@ -341,6 +342,8 @@ Response fields:
 - `abilityScores`
 - `abilityModifiers`
 - `armorClass`
+- `weaponAttacks`
+- `currency`
 - `skillProficiencies`
 - `abilityScoreRules`
 - `classDetails`
@@ -380,6 +383,8 @@ Response fields:
 - `abilityScores`
 - `abilityModifiers`
 - `armorClass`
+- `weaponAttacks`
+- `currency`
 - `abilityScoreRules`
 - `classDetails`
 - `speciesDetails`
@@ -392,6 +397,8 @@ Returns:
 - `500` with `{ "error": "Failed to fetch character detail" }`
 
 `armorClass` is calculated from the character's resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
+
+`weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
 
 ### `PATCH /api/characters/{id}`
 
@@ -407,6 +414,7 @@ Accepted fields:
 - `backgroundId`
 - `level`
 - `abilityScores`
+- `currency`
 - `skillProficiencies`
 
 Returns:
@@ -724,6 +732,37 @@ Character detail:
         "value": 10
       }
     ]
+  },
+  "weaponAttacks": [
+    {
+      "equipmentId": 42,
+      "name": "Shortbow",
+      "attackType": "ranged",
+      "ability": "DEX",
+      "isProficient": true,
+      "abilityModifier": 2,
+      "proficiencyBonus": 2,
+      "attackBonus": 4,
+      "damage": {
+        "formula": "1d6 + 2",
+        "base": "1d6",
+        "modifier": 2,
+        "damageType": "Piercing"
+      },
+      "properties": ["Ammunition", "Two-Handed"],
+      "range": {
+        "normal": 80,
+        "long": 320,
+        "unit": "ft"
+      }
+    }
+  ],
+  "currency": {
+    "cp": 0,
+    "sp": 0,
+    "ep": 0,
+    "gp": 8,
+    "pp": 0
   },
   "abilityScoreRules": {
     "source": "background",

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, calculated skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -123,6 +123,7 @@ export const apiResources: ApiResource[] = [
       'abilityScores',
       'abilityModifiers',
       'armorClass',
+      'weaponAttacks',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -135,6 +136,7 @@ export const apiResources: ApiResource[] = [
       'abilityScores',
       'abilityModifiers',
       'armorClass',
+      'weaponAttacks',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -170,5 +172,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes calculated armor class from ability modifiers and equipped gear',
+  'Character detail now includes calculated armor class and weapon attacks from equipped gear',
 ];

--- a/app/lib/character-weapon-attacks.ts
+++ b/app/lib/character-weapon-attacks.ts
@@ -1,0 +1,347 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterWeaponAttack,
+} from '@/app/types/character';
+import {
+  EquipmentDamage,
+  EquipmentMastery,
+  EquipmentProperty,
+  EquipmentRange,
+  EquipmentWeaponDetails,
+} from '@/app/types/equipment';
+import { Attributeshortname } from '@/app/types/attribute';
+import { getSql } from './db';
+
+type EquippedWeaponItem = {
+  id: number;
+  name: string;
+  details: EquipmentWeaponDetails;
+};
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function getProficiencyBonus(level: number): number {
+  if (level >= 17) {
+    return 6;
+  }
+
+  if (level >= 13) {
+    return 5;
+  }
+
+  if (level >= 9) {
+    return 4;
+  }
+
+  if (level >= 5) {
+    return 3;
+  }
+
+  return 2;
+}
+
+function parseJsonValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return null;
+    }
+  }
+
+  return value;
+}
+
+function parseEquipmentRange(value: unknown): EquipmentRange | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const range = value as Record<string, unknown>;
+
+  if (
+    (range.normal !== null && typeof range.normal !== 'number') ||
+    (range.long !== null && typeof range.long !== 'number') ||
+    range.unit !== 'ft'
+  ) {
+    return null;
+  }
+
+  return {
+    normal: range.normal as number | null,
+    long: range.long as number | null,
+    unit: 'ft',
+  };
+}
+
+function parseEquipmentDamage(value: unknown): EquipmentDamage | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const damage = value as Record<string, unknown>;
+
+  if (
+    typeof damage.formula !== 'string' ||
+    typeof damage.bonus !== 'number' ||
+    typeof damage.damageType !== 'string' ||
+    !Array.isArray(damage.dice)
+  ) {
+    return null;
+  }
+
+  const dice = damage.dice
+    .map((entry) => {
+      if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+        return null;
+      }
+
+      const die = entry as Record<string, unknown>;
+
+      return typeof die.count === 'number' && typeof die.value === 'number'
+        ? { count: die.count, value: die.value }
+        : null;
+    })
+    .filter((entry): entry is EquipmentDamage['dice'][number] => entry !== null);
+
+  if (dice.length !== damage.dice.length) {
+    return null;
+  }
+
+  return {
+    formula: damage.formula,
+    dice,
+    bonus: damage.bonus,
+    damageType: damage.damageType,
+  };
+}
+
+function parseEquipmentProperty(value: unknown): EquipmentProperty | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const property = value as Record<string, unknown>;
+
+  if (typeof property.name !== 'string' || typeof property.slug !== 'string') {
+    return null;
+  }
+
+  const range =
+    property.range === undefined ? undefined : parseEquipmentRange(property.range);
+  const damage =
+    property.damage === undefined
+      ? undefined
+      : parseEquipmentDamage(property.damage);
+
+  if (property.range !== undefined && range === null) {
+    return null;
+  }
+
+  if (property.damage !== undefined && damage === null) {
+    return null;
+  }
+
+  return {
+    name: property.name,
+    slug: property.slug,
+    range: range ?? undefined,
+    ammunitionType:
+      property.ammunitionType === undefined
+        ? undefined
+        : (property.ammunitionType as string | null),
+    damage: damage ?? undefined,
+    note:
+      property.note === undefined ? undefined : (property.note as string | null),
+  };
+}
+
+function parseEquipmentMastery(value: unknown): EquipmentMastery | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  const mastery = value as Record<string, unknown>;
+
+  if (typeof mastery.name !== 'string' || typeof mastery.slug !== 'string') {
+    return null;
+  }
+
+  return {
+    name: mastery.name,
+    slug: mastery.slug,
+  };
+}
+
+function parseWeaponDetails(value: unknown): EquipmentWeaponDetails | null {
+  const parsedValue = parseJsonValue(value);
+
+  if (
+    typeof parsedValue !== 'object' ||
+    parsedValue === null ||
+    Array.isArray(parsedValue)
+  ) {
+    return null;
+  }
+
+  const details = parsedValue as Record<string, unknown>;
+
+  if (
+    details.kind !== 'weapon' ||
+    typeof details.weaponCategory !== 'string' ||
+    typeof details.attackType !== 'string' ||
+    typeof details.proficiencyType !== 'string' ||
+    !Array.isArray(details.properties)
+  ) {
+    return null;
+  }
+
+  const damage = parseEquipmentDamage(details.damage);
+  const versatileDamage =
+    details.versatileDamage === null
+      ? null
+      : parseEquipmentDamage(details.versatileDamage);
+  const range =
+    details.range === null ? null : parseEquipmentRange(details.range);
+  const mastery = parseEquipmentMastery(details.mastery);
+  const properties = details.properties
+    .map(parseEquipmentProperty)
+    .filter((property): property is EquipmentProperty => property !== null);
+
+  if (
+    damage === null ||
+    versatileDamage === undefined ||
+    range === undefined ||
+    mastery === null ||
+    properties.length !== details.properties.length
+  ) {
+    return null;
+  }
+
+  return {
+    kind: 'weapon',
+    weaponCategory: details.weaponCategory,
+    attackType: details.attackType,
+    damage,
+    versatileDamage,
+    properties,
+    mastery,
+    range,
+    proficiencyType: details.proficiencyType,
+    ammunitionType:
+      details.ammunitionType === undefined
+        ? null
+        : (details.ammunitionType as string | null),
+  };
+}
+
+function getClassWeaponProficiencies(classSlug: string | null): Set<string> {
+  const simpleAndMartial = new Set([
+    'barbarian',
+    'fighter',
+    'paladin',
+    'ranger',
+  ]);
+
+  if (classSlug && simpleAndMartial.has(classSlug)) {
+    return new Set(['Simple Weapons', 'Martial Weapons']);
+  }
+
+  if (classSlug) {
+    return new Set(['Simple Weapons']);
+  }
+
+  return new Set();
+}
+
+function getAttackAbility(attackType: string): Attributeshortname {
+  return attackType.toLowerCase() === 'ranged' ? 'DEX' : 'STR';
+}
+
+function formatDamageFormula(baseFormula: string, modifier: number): string {
+  if (modifier === 0) {
+    return baseFormula;
+  }
+
+  return modifier > 0
+    ? `${baseFormula} + ${modifier}`
+    : `${baseFormula} - ${Math.abs(modifier)}`;
+}
+
+function formatWeaponAttack(
+  weapon: EquippedWeaponItem,
+  classSlug: string | null,
+  abilityModifiers: CharacterAbilityModifiers | null,
+  proficiencyBonus: number,
+): CharacterWeaponAttack {
+  const ability = getAttackAbility(weapon.details.attackType);
+  const abilityModifier = abilityModifiers?.[ability] ?? 0;
+  const weaponProficiencies = getClassWeaponProficiencies(classSlug);
+  const isProficient = weaponProficiencies.has(weapon.details.proficiencyType);
+  const appliedProficiencyBonus = isProficient ? proficiencyBonus : 0;
+
+  return {
+    equipmentId: weapon.id,
+    name: weapon.name,
+    attackType: weapon.details.attackType.toLowerCase(),
+    ability,
+    isProficient,
+    abilityModifier,
+    proficiencyBonus: appliedProficiencyBonus,
+    attackBonus: abilityModifier + appliedProficiencyBonus,
+    damage: {
+      formula: formatDamageFormula(
+        weapon.details.damage.formula,
+        abilityModifier,
+      ),
+      base: weapon.details.damage.formula,
+      modifier: abilityModifier,
+      damageType: weapon.details.damage.damageType,
+    },
+    properties: weapon.details.properties.map((property) => property.name),
+    range: weapon.details.range,
+  };
+}
+
+export async function getCharacterWeaponAttacks(
+  characterId: number,
+  characterLevel: number,
+  classSlug: string | null,
+  abilityModifiers: CharacterAbilityModifiers | null,
+): Promise<CharacterWeaponAttack[]> {
+  const sql = getSql();
+  const equipmentRows = await sql`
+    SELECT equipment.id, equipment.name, equipment.details
+    FROM characterequipment
+    INNER JOIN equipment ON equipment.id = characterequipment.equipmentid
+    WHERE characterequipment.characterid = ${characterId}
+      AND characterequipment.isequipped = true
+    ORDER BY characterequipment.id
+  `;
+
+  const proficiencyBonus = getProficiencyBonus(characterLevel);
+
+  return equipmentRows
+    .map((item) => {
+      const details = parseWeaponDetails(item.details);
+
+      return details
+        ? {
+            id: toNumber(item.id),
+            name: item.name,
+            details,
+          }
+        : null;
+    })
+    .filter((item): item is EquippedWeaponItem => item !== null)
+    .map((weapon) =>
+      formatWeaponAttack(
+        weapon,
+        classSlug,
+        abilityModifiers,
+        proficiencyBonus,
+      ),
+    );
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -18,6 +18,7 @@ import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getCharacterArmorClass } from './character-armor-class';
+import { getCharacterWeaponAttacks } from './character-weapon-attacks';
 import { getSql } from './db';
 
 function toNumber(value: number | string): number {
@@ -607,6 +608,12 @@ export async function formatCharacterResponse(character: {
     classDetails,
     abilityModifiers,
   );
+  const weaponAttacks = await getCharacterWeaponAttacks(
+    formattedCharacter.id,
+    formattedCharacter.level,
+    classDetails?.slug ?? null,
+    abilityModifiers,
+  );
 
   return {
     ...formattedCharacter,
@@ -615,6 +622,7 @@ export async function formatCharacterResponse(character: {
     abilityScores: formattedCharacter.abilityScores,
     abilityModifiers,
     armorClass,
+    weaponAttacks,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -85,6 +85,27 @@ export interface CharacterArmorClass {
   sources: CharacterArmorClassSource[];
 }
 
+export interface CharacterWeaponAttackDamage {
+  formula: string;
+  base: string;
+  modifier: number;
+  damageType: string;
+}
+
+export interface CharacterWeaponAttack {
+  equipmentId: number;
+  name: string;
+  attackType: string;
+  ability: Attributeshortname;
+  isProficient: boolean;
+  abilityModifier: number;
+  proficiencyBonus: number;
+  attackBonus: number;
+  damage: CharacterWeaponAttackDamage;
+  properties: string[];
+  range: import('./equipment').EquipmentRange | null;
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -157,6 +178,7 @@ export interface CharacterResponseBody {
   abilityScores: CharacterResolvedAbilityScores | null;
   abilityModifiers: CharacterAbilityModifiers | null;
   armorClass: CharacterArmorClass;
+  weaponAttacks: CharacterWeaponAttack[];
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.12.0
+  version: 1.13.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -1071,6 +1071,8 @@ paths:
                     - name: Base AC
                       type: base
                       value: 10
+                weaponAttacks: []
+                currency: null
                 skillProficiencies: []
                 abilityScoreRules: null
                 classDetails: null
@@ -1114,6 +1116,8 @@ paths:
         - `abilityScores`
         - `abilityModifiers`
         - `armorClass`
+        - `weaponAttacks`
+        - `currency`
         - `skillProficiencies`
         - `abilityScoreRules`
         - `classDetails`
@@ -1121,6 +1125,8 @@ paths:
         - `backgroundDetails`
 
         `armorClass` is calculated from resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
+
+        `weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
       security:
         - bearerAuth: []
       parameters:
@@ -1183,6 +1189,33 @@ paths:
                     - name: Base AC
                       type: base
                       value: 10
+                weaponAttacks:
+                  - equipmentId: 42
+                    name: Shortbow
+                    attackType: ranged
+                    ability: DEX
+                    isProficient: true
+                    abilityModifier: 2
+                    proficiencyBonus: 2
+                    attackBonus: 4
+                    damage:
+                      formula: 1d6 + 2
+                      base: 1d6
+                      modifier: 2
+                      damageType: Piercing
+                    properties:
+                      - Ammunition
+                      - Two-Handed
+                    range:
+                      normal: 80
+                      long: 320
+                      unit: ft
+                currency:
+                  cp: 0
+                  sp: 0
+                  ep: 0
+                  gp: 8
+                  pp: 0
                 abilityScoreRules:
                   source: background
                   allowedChoices:
@@ -3371,6 +3404,104 @@ components:
               type: base
               value: 10
 
+    CharacterCurrency:
+      type: object
+      required:
+        - cp
+        - sp
+        - ep
+        - gp
+        - pp
+      properties:
+        cp:
+          type: integer
+          example: 0
+        sp:
+          type: integer
+          example: 0
+        ep:
+          type: integer
+          example: 0
+        gp:
+          type: integer
+          example: 8
+        pp:
+          type: integer
+          example: 0
+
+    CharacterWeaponAttackDamage:
+      type: object
+      required:
+        - formula
+        - base
+        - modifier
+        - damageType
+      properties:
+        formula:
+          type: string
+          example: 1d6 + 2
+        base:
+          type: string
+          example: 1d6
+        modifier:
+          type: integer
+          example: 2
+        damageType:
+          type: string
+          example: Piercing
+
+    CharacterWeaponAttack:
+      type: object
+      required:
+        - equipmentId
+        - name
+        - attackType
+        - ability
+        - isProficient
+        - abilityModifier
+        - proficiencyBonus
+        - attackBonus
+        - damage
+        - properties
+        - range
+      properties:
+        equipmentId:
+          type: integer
+          example: 42
+        name:
+          type: string
+          example: Shortbow
+        attackType:
+          type: string
+          example: ranged
+        ability:
+          $ref: '#/components/schemas/AttributeShortname'
+        isProficient:
+          type: boolean
+          example: true
+        abilityModifier:
+          type: integer
+          example: 2
+        proficiencyBonus:
+          type: integer
+          example: 2
+        attackBonus:
+          type: integer
+          example: 4
+        damage:
+          $ref: '#/components/schemas/CharacterWeaponAttackDamage'
+        properties:
+          type: array
+          items:
+            type: string
+          example:
+            - Ammunition
+            - Two-Handed
+        range:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/EquipmentRange'
+
     CharacterAbilityScoreBonusChoice:
       type: object
       required:
@@ -3493,6 +3624,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityScoresInput'
+        currency:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterCurrency'
         skillProficiencies:
           type: array
           items:
@@ -3531,6 +3666,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterAbilityScoresInput'
+        currency:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterCurrency'
         skillProficiencies:
           type: array
           items:
@@ -3653,6 +3792,8 @@ components:
         - abilityScores
         - abilityModifiers
         - armorClass
+        - weaponAttacks
+        - currency
         - skillProficiencies
         - abilityScoreRules
         - classDetails
@@ -3699,6 +3840,14 @@ components:
             - $ref: '#/components/schemas/CharacterAbilityModifiers'
         armorClass:
           $ref: '#/components/schemas/CharacterArmorClass'
+        weaponAttacks:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterWeaponAttack'
+        currency:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterCurrency'
         skillProficiencies:
           type: array
           items:

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -70,6 +70,15 @@ const drizztAbilityScores: CharacterAbilityScores = {
   CHA: 12,
 };
 
+const gimliAbilityScores: CharacterAbilityScores = {
+  STR: 15,
+  DEX: 13,
+  CON: 14,
+  INT: 8,
+  WIS: 12,
+  CHA: 10,
+};
+
 const barbarianAbilityBonuses: CharacterAbilityScores = {
   STR: 2,
   DEX: 0,
@@ -115,6 +124,15 @@ const drizztAbilityBonuses: CharacterAbilityScores = {
   CHA: 0,
 };
 
+const gimliAbilityBonuses: CharacterAbilityScores = {
+  STR: 2,
+  DEX: 0,
+  CON: 1,
+  INT: 0,
+  WIS: 0,
+  CHA: 0,
+};
+
 const barbarianAbilityScoresInput: CharacterAbilityScoresInput = {
   base: barbarianAbilityScores,
   bonuses: barbarianAbilityBonuses,
@@ -138,6 +156,11 @@ const aangAbilityScoresInput: CharacterAbilityScoresInput = {
 const drizztAbilityScoresInput: CharacterAbilityScoresInput = {
   base: drizztAbilityScores,
   bonuses: drizztAbilityBonuses,
+};
+
+const gimliAbilityScoresInput: CharacterAbilityScoresInput = {
+  base: gimliAbilityScores,
+  bonuses: gimliAbilityBonuses,
 };
 
 const patchedCurrency: CharacterCurrency = {
@@ -1129,6 +1152,23 @@ test.describe(
         finalCharacter.armorClass,
         barbarianArmorClass,
       );
+      await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
+        name: 'Greataxe',
+        attackType: 'melee',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        attackBonus: 5,
+        damage: {
+          formula: '1d12 + 3',
+          base: '1d12',
+          modifier: 3,
+          damageType: 'Slashing',
+        },
+        properties: ['Heavy', 'Two-Handed'],
+        rangeExists: false,
+      });
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
         expectedDetailedBackgrounds.soldier.abilityScores,
@@ -1360,6 +1400,23 @@ test.describe(
         character.armorClass,
         aangArmorClass,
       );
+      await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
+        name: 'Quarterstaff',
+        attackType: 'melee',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 0,
+        proficiencyBonus: 2,
+        attackBonus: 2,
+        damage: {
+          formula: '1d6',
+          base: '1d6',
+          modifier: 0,
+          damageType: 'Bludgeoning',
+        },
+        properties: ['Versatile'],
+        rangeExists: false,
+      });
     },
   );
   },
@@ -1868,6 +1925,31 @@ test.describe(
       await charactersAssert.validateArmorClass(
         character.armorClass,
         paladinArmorClass,
+      );
+      await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
+        name: 'Longsword',
+        attackType: 'melee',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        attackBonus: 5,
+        damage: {
+          formula: '1d8 + 3',
+          base: '1d8',
+          modifier: 3,
+          damageType: 'Slashing',
+        },
+        properties: ['Versatile'],
+        rangeExists: false,
+      });
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Chain Mail',
+      );
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Shield',
       );
       await charactersAssert.validateCurrency(character.currency, nobleCurrency);
       await charactersAssert.validateAbilityScoreRules(
@@ -2857,6 +2939,27 @@ test.describe(
         finalCharacter.armorClass,
         wizardArmorClass,
       );
+      await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
+        name: 'Quarterstaff',
+        attackType: 'melee',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: -1,
+        proficiencyBonus: 2,
+        attackBonus: 1,
+        damage: {
+          formula: '1d6 - 1',
+          base: '1d6',
+          modifier: -1,
+          damageType: 'Bludgeoning',
+        },
+        properties: ['Versatile'],
+        rangeExists: false,
+      });
+      await charactersAssert.validateWeaponAttackAbsent(
+        finalCharacter.weaponAttacks,
+        'Robe',
+      );
       await charactersAssert.validateAbilityScoreRules(
         finalCharacter.abilityScoreRules,
         expectedDetailedBackgrounds.sage.abilityScores,
@@ -3407,16 +3510,23 @@ test.describe(
   let characterWithoutEquipmentId: number;
   let characterWithEquipmentId: number;
   let greataxeEquipmentId: number;
+  let shortbowEquipmentId: number;
 
   test.beforeAll(async ({ request }) => {
     authToken = await issueDemoToken(request);
 
     const equipmentClient = new EquipmentClient(request);
-    const equipmentResponse = await equipmentClient.getEquipmentDetail('greataxe');
-    expect(equipmentResponse.status()).toBe(200);
-    const equipment: EquipmentDetail = await equipmentResponse.json();
-    expect(equipment.name).toBe('Greataxe');
-    greataxeEquipmentId = equipment.id;
+    const greataxeResponse = await equipmentClient.getEquipmentDetail('greataxe');
+    expect(greataxeResponse.status()).toBe(200);
+    const greataxe: EquipmentDetail = await greataxeResponse.json();
+    expect(greataxe.name).toBe('Greataxe');
+    greataxeEquipmentId = greataxe.id;
+
+    const shortbowResponse = await equipmentClient.getEquipmentDetail('shortbow');
+    expect(shortbowResponse.status()).toBe(200);
+    const shortbow: EquipmentDetail = await shortbowResponse.json();
+    expect(shortbow.name).toBe('Shortbow');
+    shortbowEquipmentId = shortbow.id;
   });
 
   test(
@@ -3433,6 +3543,7 @@ test.describe(
           speciesId: 2,
           backgroundId: 16,
           level: 1,
+          abilityScores: gimliAbilityScoresInput,
         },
         authToken,
       );
@@ -3446,6 +3557,11 @@ test.describe(
       await charactersAssert.validateClassId(character.classId, 5);
       await charactersAssert.validateSpeciesId(character.speciesId, 2);
       await charactersAssert.validateBackgroundId(character.backgroundId, 16);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        gimliAbilityScores,
+        gimliAbilityBonuses,
+      );
       await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
@@ -3476,6 +3592,21 @@ test.describe(
       await test.step('Validate character has no equipment', async () => {
         expect(characterEquipment.equipment).toEqual([]);
       });
+
+      const detailResponse = await charactersClient.getCharacterDetail(
+        characterWithoutEquipmentId,
+        authToken,
+      );
+
+      await charactersAssert.success(detailResponse);
+
+      const character: CharacterResponseBody = await detailResponse.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+
+      await test.step('Validate character has no weapon attacks', async () => {
+        expect(character.weaponAttacks).toEqual([]);
+      });
     },
   );
 
@@ -3493,6 +3624,7 @@ test.describe(
           speciesId: 2,
           backgroundId: 16,
           level: 1,
+          abilityScores: gimliAbilityScoresInput,
         },
         authToken,
       );
@@ -3506,6 +3638,11 @@ test.describe(
       await charactersAssert.validateClassId(character.classId, 5);
       await charactersAssert.validateSpeciesId(character.speciesId, 2);
       await charactersAssert.validateBackgroundId(character.backgroundId, 16);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        gimliAbilityScores,
+        gimliAbilityBonuses,
+      );
       await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
@@ -3522,6 +3659,8 @@ test.describe(
         authToken,
         [
           { slug: 'greataxe', quantity: 1, isEquipped: true },
+          { slug: 'shortbow', quantity: 1, isEquipped: true },
+          { slug: 'dagger', quantity: 1, isEquipped: false },
           { slug: 'chain-mail', quantity: 1, isEquipped: true },
           { slug: 'shield', quantity: 1, isEquipped: true },
         ],
@@ -3540,6 +3679,8 @@ test.describe(
       });
       await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
         { name: 'Greataxe', quantity: 1, isEquipped: true },
+        { name: 'Shortbow', quantity: 1, isEquipped: true },
+        { name: 'Dagger', quantity: 1, isEquipped: false },
         { name: 'Chain Mail', quantity: 1, isEquipped: true },
         { name: 'Shield', quantity: 1, isEquipped: true },
       ]);
@@ -3575,9 +3716,79 @@ test.describe(
       });
       await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
         { name: 'Greataxe', quantity: 1, isEquipped: true },
+        { name: 'Shortbow', quantity: 1, isEquipped: true },
+        { name: 'Dagger', quantity: 1, isEquipped: false },
         { name: 'Chain Mail', quantity: 1, isEquipped: true },
         { name: 'Shield', quantity: 1, isEquipped: true },
       ]);
+    },
+  );
+
+  test(
+    'Get Gimli Weapon Attacks',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        characterWithEquipmentId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
+        equipmentId: greataxeEquipmentId,
+        name: 'Greataxe',
+        attackType: 'melee',
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        attackBonus: 5,
+        damage: {
+          formula: '1d12 + 3',
+          base: '1d12',
+          modifier: 3,
+          damageType: 'Slashing',
+        },
+        properties: ['Heavy', 'Two-Handed'],
+        rangeExists: false,
+      });
+      await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
+        equipmentId: shortbowEquipmentId,
+        name: 'Shortbow',
+        attackType: 'ranged',
+        ability: 'DEX',
+        isProficient: true,
+        abilityModifier: 1,
+        proficiencyBonus: 2,
+        attackBonus: 3,
+        damage: {
+          formula: '1d6 + 1',
+          base: '1d6',
+          modifier: 1,
+          damageType: 'Piercing',
+        },
+        properties: ['Ammunition', 'Two-Handed'],
+        rangeExists: true,
+      });
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Dagger',
+      );
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Chain Mail',
+      );
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Shield',
+      );
     },
   );
 
@@ -3614,6 +3825,8 @@ test.describe(
         isEquipped: false,
       });
       await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Shortbow', quantity: 1, isEquipped: true },
+        { name: 'Dagger', quantity: 1, isEquipped: false },
         { name: 'Chain Mail', quantity: 1, isEquipped: true },
         { name: 'Shield', quantity: 1, isEquipped: true },
       ]);
@@ -3717,6 +3930,8 @@ test.describe(
         greataxeEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Shortbow', quantity: 1, isEquipped: true },
+        { name: 'Dagger', quantity: 1, isEquipped: false },
         { name: 'Chain Mail', quantity: 1, isEquipped: true },
         { name: 'Shield', quantity: 1, isEquipped: true },
       ]);
@@ -3750,9 +3965,44 @@ test.describe(
         greataxeEquipmentId,
       );
       await charactersAssert.validateCharacterEquipmentItems(characterEquipment, [
+        { name: 'Shortbow', quantity: 1, isEquipped: true },
+        { name: 'Dagger', quantity: 1, isEquipped: false },
         { name: 'Chain Mail', quantity: 1, isEquipped: true },
         { name: 'Shield', quantity: 1, isEquipped: true },
       ]);
+
+      const detailResponse = await charactersClient.getCharacterDetail(
+        characterWithEquipmentId,
+        authToken,
+      );
+
+      await charactersAssert.success(detailResponse);
+
+      const character: CharacterResponseBody = await detailResponse.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Greataxe',
+      );
+      await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
+        equipmentId: shortbowEquipmentId,
+        name: 'Shortbow',
+        attackType: 'ranged',
+        ability: 'DEX',
+        isProficient: true,
+        abilityModifier: 1,
+        proficiencyBonus: 2,
+        attackBonus: 3,
+      });
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Chain Mail',
+      );
+      await charactersAssert.validateWeaponAttackAbsent(
+        character.weaponAttacks,
+        'Shield',
+      );
     },
   );
   },

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -13,6 +13,7 @@ import {
   CharacterSpellSelectionResponseBody,
   CharacterResponseBody,
   CharacterStatus,
+  CharacterWeaponAttack,
 } from '@/app/types/character';
 import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail } from '@/app/types/species';
@@ -284,6 +285,154 @@ export class CharactersAssert {
     });
   }
 
+  async validateWeaponAttacksSchema(weaponAttacks: CharacterWeaponAttack[]) {
+    await test.step('Validate weapon attacks schema', async () => {
+      expect(Array.isArray(weaponAttacks)).toBe(true);
+    });
+
+    for (const weaponAttack of weaponAttacks) {
+      await test.step(
+        `Validate weapon attack schema for ${weaponAttack.name}`,
+        async () => {
+          expect(weaponAttack).toHaveProperty('equipmentId');
+          expect(weaponAttack).toHaveProperty('name');
+          expect(weaponAttack).toHaveProperty('attackType');
+          expect(weaponAttack).toHaveProperty('ability');
+          expect(weaponAttack).toHaveProperty('isProficient');
+          expect(weaponAttack).toHaveProperty('abilityModifier');
+          expect(weaponAttack).toHaveProperty('proficiencyBonus');
+          expect(weaponAttack).toHaveProperty('attackBonus');
+          expect(weaponAttack).toHaveProperty('damage');
+          expect(weaponAttack).toHaveProperty('properties');
+          expect(weaponAttack).toHaveProperty('range');
+
+          expect(typeof weaponAttack.equipmentId).toBe('number');
+          expect(typeof weaponAttack.name).toBe('string');
+          expect(typeof weaponAttack.attackType).toBe('string');
+          expect(typeof weaponAttack.ability).toBe('string');
+          expect(typeof weaponAttack.isProficient).toBe('boolean');
+          expect(typeof weaponAttack.abilityModifier).toBe('number');
+          expect(typeof weaponAttack.proficiencyBonus).toBe('number');
+          expect(typeof weaponAttack.attackBonus).toBe('number');
+          expect(Array.isArray(weaponAttack.properties)).toBe(true);
+          expect(
+            weaponAttack.range === null || typeof weaponAttack.range === 'object',
+          ).toBe(true);
+        },
+      );
+
+      await test.step(
+        `Validate weapon attack damage schema for ${weaponAttack.name}`,
+        async () => {
+          expect(weaponAttack.damage).toHaveProperty('formula');
+          expect(weaponAttack.damage).toHaveProperty('base');
+          expect(weaponAttack.damage).toHaveProperty('modifier');
+          expect(weaponAttack.damage).toHaveProperty('damageType');
+
+          expect(typeof weaponAttack.damage.formula).toBe('string');
+          expect(typeof weaponAttack.damage.base).toBe('string');
+          expect(typeof weaponAttack.damage.modifier).toBe('number');
+          expect(typeof weaponAttack.damage.damageType).toBe('string');
+        },
+      );
+
+      for (const property of weaponAttack.properties) {
+        await test.step(
+          `Validate weapon attack property schema for ${property}`,
+          async () => {
+            expect(typeof property).toBe('string');
+          },
+        );
+      }
+    }
+  }
+
+  async validateWeaponAttack(
+    weaponAttacks: CharacterWeaponAttack[],
+    expectedAttack: {
+      name: string;
+      equipmentId?: number;
+      attackType?: string;
+      ability?: CharacterWeaponAttack['ability'];
+      isProficient?: boolean;
+      abilityModifier?: number;
+      proficiencyBonus?: number;
+      attackBonus?: number;
+      damage?: Partial<CharacterWeaponAttack['damage']>;
+      properties?: string[];
+      rangeExists?: boolean;
+    },
+  ) {
+    await test.step(`Validate weapon attack for ${expectedAttack.name}`, async () => {
+      const weaponAttack = weaponAttacks.find(
+        (attack) => attack.name === expectedAttack.name,
+      );
+
+      expect(weaponAttack).toBeDefined();
+
+      if (expectedAttack.equipmentId !== undefined) {
+        expect(weaponAttack?.equipmentId).toBe(expectedAttack.equipmentId);
+      }
+
+      if (expectedAttack.attackType !== undefined) {
+        expect(weaponAttack?.attackType).toBe(expectedAttack.attackType);
+      }
+
+      if (expectedAttack.ability !== undefined) {
+        expect(weaponAttack?.ability).toBe(expectedAttack.ability);
+      }
+
+      if (expectedAttack.isProficient !== undefined) {
+        expect(weaponAttack?.isProficient).toBe(expectedAttack.isProficient);
+      }
+
+      if (expectedAttack.abilityModifier !== undefined) {
+        expect(weaponAttack?.abilityModifier).toBe(
+          expectedAttack.abilityModifier,
+        );
+      }
+
+      if (expectedAttack.proficiencyBonus !== undefined) {
+        expect(weaponAttack?.proficiencyBonus).toBe(
+          expectedAttack.proficiencyBonus,
+        );
+      }
+
+      if (expectedAttack.attackBonus !== undefined) {
+        expect(weaponAttack?.attackBonus).toBe(expectedAttack.attackBonus);
+      }
+
+      if (expectedAttack.damage) {
+        expect(weaponAttack?.damage).toMatchObject(expectedAttack.damage);
+      }
+
+      if (expectedAttack.properties) {
+        expect(weaponAttack?.properties).toEqual(
+          expect.arrayContaining(expectedAttack.properties),
+        );
+      }
+
+      if (expectedAttack.rangeExists !== undefined) {
+        if (expectedAttack.rangeExists) {
+          expect(weaponAttack?.range).not.toBeNull();
+        } else {
+          expect(weaponAttack?.range).toBeNull();
+        }
+      }
+    });
+  }
+
+  async validateWeaponAttackAbsent(
+    weaponAttacks: CharacterWeaponAttack[],
+    weaponName: string,
+  ) {
+    await test.step(`Validate ${weaponName} is absent from weapon attacks`, async () => {
+      expect(weaponAttacks.some((attack) => attack.name === weaponName)).toBe(
+        false,
+      );
+    });
+  }
+
   async validateCharacterSpellSelectionSchema(
     spellSelection: CharacterSpellSelectionResponseBody,
   ) {
@@ -415,6 +564,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('abilityScores');
       expect(character).toHaveProperty('abilityModifiers');
       expect(character).toHaveProperty('armorClass');
+      expect(character).toHaveProperty('weaponAttacks');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -446,6 +596,7 @@ export class CharactersAssert {
           typeof character.abilityModifiers === 'object',
       ).toBe(true);
       expect(typeof character.armorClass).toBe('object');
+      expect(Array.isArray(character.weaponAttacks)).toBe(true);
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -492,6 +643,7 @@ export class CharactersAssert {
     }
 
     await this.validateArmorClassSchema(character.armorClass);
+    await this.validateWeaponAttacksSchema(character.weaponAttacks);
 
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);


### PR DESCRIPTION
## Summary

This PR adds `weaponAttacks` to character detail responses.

The new weapon attack summary is derived from equipped character weapons, ability modifiers, weapon proficiency, and equipment weapon details.

## What Changed

- added `weaponAttacks` to `GET /api/characters/[id]`
- derived weapon attacks from equipped character equipment
- ignored unequipped weapons in attack calculations
- calculated melee weapon attacks using `STR`
- calculated ranged weapon attacks using `DEX`
- calculated `attackBonus` from ability modifier and proficiency bonus when applicable
- calculated basic weapon damage display from equipment damage data
- included weapon properties and range in the response
- added shared character response types for weapon attacks
- added character weapon attack helper logic
- expanded automated character tests for weapon attack scenarios
- updated OpenAPI documentation and README examples

## API Behavior

The character detail response now includes a `weaponAttacks` array.

Example:

```json
{
  "weaponAttacks": [
    {
      "equipmentId": 12,
      "name": "Longsword",
      "attackType": "melee",
      "ability": "STR",
      "isProficient": true,
      "abilityModifier": 3,
      "proficiencyBonus": 2,
      "attackBonus": 5,
      "damage": {
        "formula": "1d8 + 3",
        "base": "1d8",
        "modifier": 3,
        "damageType": "Slashing"
      },
      "properties": ["Versatile"],
      "range": null
    }
  ]
}
```

## Calculation Rules

For this first version:

- only equipped weapons are included
- unequipped weapons are ignored
- melee weapons use `STR`
- ranged weapons use `DEX`
- proficiency bonus is added only when the character is proficient with the weapon
- damage is displayed as weapon base damage plus the relevant ability modifier
- weapon properties and range are included as informational fields

## Why

The character sheet already supports:

- ability scores
- ability modifiers
- proficiency bonus
- equipment
- equipped state
- armor class

Adding `weaponAttacks` is the next step toward making the character sheet more useful for combat-related flows.

## Testing

This PR includes coverage for:

- equipped melee weapon attacks
- equipped ranged weapon attacks
- unequipped weapons being ignored
- attack bonus calculation
- damage formula calculation
- weapon property and range output
- empty weapon attack arrays when no weapon is equipped

## Notes

This PR focuses only on basic weapon attack summaries.

It does not yet include:

- finesse weapon choice
- thrown weapon alternate ability rules
- versatile damage selection
- dual wielding
- fighting styles
- magic weapon bonuses
- temporary bonuses
- attack rolling
- damage rolling
- critical hits