### PR TITLE
feat: add character hit point calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ Response fields:
 - `abilityModifiers`
 - `armorClass`
 - `weaponAttacks`
+- `hitPoints`
 - `currency`
 - `skillProficiencies`
 - `abilityScoreRules`
@@ -384,6 +385,7 @@ Response fields:
 - `abilityModifiers`
 - `armorClass`
 - `weaponAttacks`
+- `hitPoints`
 - `currency`
 - `abilityScoreRules`
 - `classDetails`
@@ -399,6 +401,8 @@ Returns:
 `armorClass` is calculated from the character's resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
 
 `weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
+
+`hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
 
 ### `PATCH /api/characters/{id}`
 
@@ -757,6 +761,14 @@ Character detail:
       }
     }
   ],
+  "hitPoints": {
+    "max": 7,
+    "current": 7,
+    "temporary": 0,
+    "hitDie": 6,
+    "conModifier": 1,
+    "calculation": "6 + 1"
+  },
   "currency": {
     "cp": 0,
     "sp": 0,

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, hit point calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated hit points, calculated skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -124,6 +124,7 @@ export const apiResources: ApiResource[] = [
       'abilityModifiers',
       'armorClass',
       'weaponAttacks',
+      'hitPoints',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -137,6 +138,7 @@ export const apiResources: ApiResource[] = [
       'abilityModifiers',
       'armorClass',
       'weaponAttacks',
+      'hitPoints',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -172,5 +174,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes calculated armor class and weapon attacks from equipped gear',
+  'Character detail now includes calculated armor class, weapon attacks, and hit points',
 ];

--- a/app/lib/character-hit-points.ts
+++ b/app/lib/character-hit-points.ts
@@ -1,0 +1,52 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterClassDetails,
+  CharacterHitPoints,
+} from '@/app/types/character';
+
+function getAverageHitDie(hitDie: number): number | null {
+  const averageHitDieByDie: Record<number, number> = {
+    6: 4,
+    8: 5,
+    10: 6,
+    12: 7,
+  };
+
+  return averageHitDieByDie[hitDie] ?? null;
+}
+
+export function getCharacterHitPoints(
+  classDetails: CharacterClassDetails | null,
+  level: number,
+  abilityModifiers: CharacterAbilityModifiers | null,
+): CharacterHitPoints | null {
+  if (!classDetails || !abilityModifiers) {
+    return null;
+  }
+
+  const hitDie = classDetails.hitDie;
+  const averageHitDie = getAverageHitDie(hitDie);
+
+  if (averageHitDie === null || level <= 0) {
+    return null;
+  }
+
+  const conModifier = abilityModifiers.CON;
+  const max =
+    level === 1
+      ? hitDie + conModifier
+      : hitDie + conModifier + (level - 1) * (averageHitDie + conModifier);
+  const calculation =
+    level === 1
+      ? `${hitDie} + ${conModifier}`
+      : `${hitDie} + ${conModifier} + (${level - 1} * (${averageHitDie} + ${conModifier}))`;
+
+  return {
+    max,
+    current: max,
+    temporary: 0,
+    hitDie,
+    conModifier,
+    calculation,
+  };
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -18,6 +18,7 @@ import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getCharacterArmorClass } from './character-armor-class';
+import { getCharacterHitPoints } from './character-hit-points';
 import { getCharacterWeaponAttacks } from './character-weapon-attacks';
 import { getSql } from './db';
 
@@ -614,6 +615,11 @@ export async function formatCharacterResponse(character: {
     classDetails?.slug ?? null,
     abilityModifiers,
   );
+  const hitPoints = getCharacterHitPoints(
+    classDetails,
+    formattedCharacter.level,
+    abilityModifiers,
+  );
 
   return {
     ...formattedCharacter,
@@ -623,6 +629,7 @@ export async function formatCharacterResponse(character: {
     abilityModifiers,
     armorClass,
     weaponAttacks,
+    hitPoints,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -106,6 +106,15 @@ export interface CharacterWeaponAttack {
   range: import('./equipment').EquipmentRange | null;
 }
 
+export interface CharacterHitPoints {
+  max: number;
+  current: number;
+  temporary: number;
+  hitDie: number;
+  conModifier: number;
+  calculation: string;
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -179,6 +188,7 @@ export interface CharacterResponseBody {
   abilityModifiers: CharacterAbilityModifiers | null;
   armorClass: CharacterArmorClass;
   weaponAttacks: CharacterWeaponAttack[];
+  hitPoints: CharacterHitPoints | null;
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.13.0
+  version: 1.14.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -1072,6 +1072,7 @@ paths:
                       type: base
                       value: 10
                 weaponAttacks: []
+                hitPoints: null
                 currency: null
                 skillProficiencies: []
                 abilityScoreRules: null
@@ -1117,6 +1118,7 @@ paths:
         - `abilityModifiers`
         - `armorClass`
         - `weaponAttacks`
+        - `hitPoints`
         - `currency`
         - `skillProficiencies`
         - `abilityScoreRules`
@@ -1127,6 +1129,8 @@ paths:
         `armorClass` is calculated from resolved DEX modifier and currently equipped armor or shield. If no armor is equipped, the base AC is `10`; Barbarian and Monk unarmored defense can contribute a `class` source when their rules apply.
 
         `weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
+
+        `hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
       security:
         - bearerAuth: []
       parameters:
@@ -1210,6 +1214,13 @@ paths:
                       normal: 80
                       long: 320
                       unit: ft
+                hitPoints:
+                  max: 7
+                  current: 7
+                  temporary: 0
+                  hitDie: 6
+                  conModifier: 1
+                  calculation: 6 + 1
                 currency:
                   cp: 0
                   sp: 0
@@ -3502,6 +3513,35 @@ components:
           allOf:
             - $ref: '#/components/schemas/EquipmentRange'
 
+    CharacterHitPoints:
+      type: object
+      required:
+        - max
+        - current
+        - temporary
+        - hitDie
+        - conModifier
+        - calculation
+      properties:
+        max:
+          type: integer
+          example: 7
+        current:
+          type: integer
+          example: 7
+        temporary:
+          type: integer
+          example: 0
+        hitDie:
+          type: integer
+          example: 6
+        conModifier:
+          type: integer
+          example: 1
+        calculation:
+          type: string
+          example: 6 + 1
+
     CharacterAbilityScoreBonusChoice:
       type: object
       required:
@@ -3793,6 +3833,7 @@ components:
         - abilityModifiers
         - armorClass
         - weaponAttacks
+        - hitPoints
         - currency
         - skillProficiencies
         - abilityScoreRules
@@ -3844,6 +3885,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CharacterWeaponAttack'
+        hitPoints:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterHitPoints'
         currency:
           nullable: true
           allOf:

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -7,6 +7,7 @@ import {
   CharacterCreateRequestBody,
   CharacterCurrency,
   CharacterEquipmentResponseBody,
+  CharacterHitPoints,
   CharacterSkillItem,
   CharacterListItem,
   CharacterResponseBody,
@@ -248,6 +249,51 @@ const aangArmorClass: CharacterArmorClass = {
   ],
 };
 
+const barbarianHitPoints: CharacterHitPoints = {
+  max: 14,
+  current: 14,
+  temporary: 0,
+  hitDie: 12,
+  conModifier: 2,
+  calculation: '12 + 2',
+};
+
+const monkHitPoints: CharacterHitPoints = {
+  max: 10,
+  current: 10,
+  temporary: 0,
+  hitDie: 8,
+  conModifier: 2,
+  calculation: '8 + 2',
+};
+
+const paladinHitPoints: CharacterHitPoints = {
+  max: 25,
+  current: 25,
+  temporary: 0,
+  hitDie: 10,
+  conModifier: 1,
+  calculation: '10 + 1 + (2 * (6 + 1))',
+};
+
+const wizardHitPoints: CharacterHitPoints = {
+  max: 7,
+  current: 7,
+  temporary: 0,
+  hitDie: 6,
+  conModifier: 1,
+  calculation: '6 + 1',
+};
+
+const fighterHitPoints: CharacterHitPoints = {
+  max: 12,
+  current: 12,
+  temporary: 0,
+  hitDie: 10,
+  conModifier: 2,
+  calculation: '10 + 2',
+};
+
 const barbarianSkillProficiencies: SkillName[] = [
   'Athletics',
   'Intimidation',
@@ -396,6 +442,7 @@ test.describe(
         createdCharacter.abilityScoreRules,
         null,
       );
+      await charactersAssert.validateHitPoints(createdCharacter.hitPoints, null);
       await charactersAssert.validateClassDetailsPresence(
         createdCharacter.classDetails ?? null,
         false,
@@ -511,6 +558,7 @@ test.describe(
         updatedCharacter.abilityScores,
         null,
       );
+      await charactersAssert.validateHitPoints(updatedCharacter.hitPoints, null);
       await charactersAssert.validateClassDetailsPresence(
         updatedCharacter.classDetails ?? null,
         true,
@@ -1152,6 +1200,10 @@ test.describe(
         finalCharacter.armorClass,
         barbarianArmorClass,
       );
+      await charactersAssert.validateHitPoints(
+        finalCharacter.hitPoints,
+        barbarianHitPoints,
+      );
       await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
         name: 'Greataxe',
         attackType: 'melee',
@@ -1280,6 +1332,7 @@ test.describe(
       await charactersAssert.validateLevel(character.level, 1);
       await charactersAssert.validateMissingFields(character.missingFields, []);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
+      await charactersAssert.validateHitPoints(character.hitPoints, null);
       await charactersAssert.validateCurrency(character.currency, acolyteCurrency);
       await charactersAssert.validateAbilityScoreRules(
         character.abilityScoreRules,
@@ -1399,6 +1452,10 @@ test.describe(
       await charactersAssert.validateArmorClass(
         character.armorClass,
         aangArmorClass,
+      );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        monkHitPoints,
       );
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         name: 'Quarterstaff',
@@ -1925,6 +1982,10 @@ test.describe(
       await charactersAssert.validateArmorClass(
         character.armorClass,
         paladinArmorClass,
+      );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        paladinHitPoints,
       );
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         name: 'Longsword',
@@ -2939,6 +3000,10 @@ test.describe(
         finalCharacter.armorClass,
         wizardArmorClass,
       );
+      await charactersAssert.validateHitPoints(
+        finalCharacter.hitPoints,
+        wizardHitPoints,
+      );
       await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
         name: 'Quarterstaff',
         attackType: 'melee',
@@ -3562,6 +3627,10 @@ test.describe(
         gimliAbilityScores,
         gimliAbilityBonuses,
       );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
+      );
       await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
@@ -3603,6 +3672,10 @@ test.describe(
       const character: CharacterResponseBody = await detailResponse.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
+      );
 
       await test.step('Validate character has no weapon attacks', async () => {
         expect(character.weaponAttacks).toEqual([]);
@@ -3642,6 +3715,10 @@ test.describe(
         character.abilityScores,
         gimliAbilityScores,
         gimliAbilityBonuses,
+      );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
       );
       await charactersAssert.validateStatus(character.status, 'complete');
     },
@@ -3741,6 +3818,10 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
+      );
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         equipmentId: greataxeEquipmentId,
         name: 'Greataxe',
@@ -3981,6 +4062,10 @@ test.describe(
       const character: CharacterResponseBody = await detailResponse.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
+      );
       await charactersAssert.validateWeaponAttackAbsent(
         character.weaponAttacks,
         'Greataxe',

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -7,6 +7,7 @@ import {
   CharacterResolvedAbilityScores,
   CharacterClassDetails,
   CharacterEquipmentResponseBody,
+  CharacterHitPoints,
   CharacterListItem,
   CharacterSkillItem,
   CharacterSpellOptionsResponseBody,
@@ -565,6 +566,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('abilityModifiers');
       expect(character).toHaveProperty('armorClass');
       expect(character).toHaveProperty('weaponAttacks');
+      expect(character).toHaveProperty('hitPoints');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -597,6 +599,9 @@ export class CharactersAssert {
       ).toBe(true);
       expect(typeof character.armorClass).toBe('object');
       expect(Array.isArray(character.weaponAttacks)).toBe(true);
+      expect(
+        character.hitPoints === null || typeof character.hitPoints === 'object',
+      ).toBe(true);
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -644,6 +649,10 @@ export class CharactersAssert {
 
     await this.validateArmorClassSchema(character.armorClass);
     await this.validateWeaponAttacksSchema(character.weaponAttacks);
+
+    if (character.hitPoints) {
+      await this.validateHitPointsSchema(character.hitPoints);
+    }
 
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
@@ -896,6 +905,45 @@ export class CharactersAssert {
     });
 
     await this.validateArmorClassSchema(armorClass);
+  }
+
+  async validateHitPointsSchema(hitPoints: CharacterHitPoints) {
+    await test.step('Validate hit points schema', async () => {
+      expect(hitPoints).toHaveProperty('max');
+      expect(hitPoints).toHaveProperty('current');
+      expect(hitPoints).toHaveProperty('temporary');
+      expect(hitPoints).toHaveProperty('hitDie');
+      expect(hitPoints).toHaveProperty('conModifier');
+      expect(hitPoints).toHaveProperty('calculation');
+
+      expect(typeof hitPoints.max).toBe('number');
+      expect(typeof hitPoints.current).toBe('number');
+      expect(typeof hitPoints.temporary).toBe('number');
+      expect(typeof hitPoints.hitDie).toBe('number');
+      expect(typeof hitPoints.conModifier).toBe('number');
+      expect(typeof hitPoints.calculation).toBe('string');
+    });
+  }
+
+  async validateHitPoints(
+    hitPoints: CharacterResponseBody['hitPoints'],
+    expectedHitPoints: CharacterHitPoints | null,
+  ) {
+    await test.step('Validate Hit Points', async () => {
+      if (expectedHitPoints === null) {
+        expect(hitPoints).toBeNull();
+
+        return;
+      }
+
+      expect(hitPoints).toEqual(expectedHitPoints);
+      expect(hitPoints?.current).toBe(hitPoints?.max);
+      expect(hitPoints?.temporary).toBe(0);
+    });
+
+    if (hitPoints) {
+      await this.validateHitPointsSchema(hitPoints);
+    }
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR adds `hitPoints` calculation to character detail responses.

The new HP block is derived from the character’s class hit die, level, and Constitution modifier, making the character sheet more complete and preparing the API for future combat-related features.

## What Changed

- added `hitPoints` to `GET /api/characters/[id]`
- calculated max HP from class hit die, character level, and `CON` modifier
- used fixed average hit die progression for levels above 1
- set `current` HP equal to `max` for this first version
- set `temporary` HP to `0` for this first version
- returned `hitPoints: null` when required data is missing
- added shared hit point calculation helper logic
- updated character response types and API resource metadata
- expanded character test coverage and reusable assertions for HP scenarios

## API Behavior

The character detail response now includes a `hitPoints` block when the required data exists.

Example:

```json
{
  "hitPoints": {
    "max": 12,
    "current": 12,
    "temporary": 0,
    "hitDie": 10,
    "conModifier": 2,
    "calculation": "10 + 2"
  }
}
```

If required character data is missing, the response returns:

```json
{
  "hitPoints": null
}
```

## Calculation Rules

For this first version:

- `hitDie` comes from `classDetails.hitDie`
- `conModifier` comes from `abilityModifiers.CON`
- at level 1:
  - `max = hitDie + CON modifier`
- above level 1:
  - `max = hitDie + CON modifier + ((level - 1) * (averageHitDie + CON modifier))`
- fixed hit die average:
  - `d6 -> 4`
  - `d8 -> 5`
  - `d10 -> 6`
  - `d12 -> 7`
- `current = max`
- `temporary = 0`

## Why

The character sheet already supports:

- class details
- level
- ability scores
- ability modifiers
- armor class
- weapon attacks

Adding `hitPoints` is the next step toward making the character sheet more complete and useful for future combat and gameplay systems.

## Testing

This PR includes coverage for:

- level 1 hit point calculation
- higher-level hit point calculation using fixed average progression
- different hit dice and `CON` modifiers
- `current` matching `max`
- `temporary` defaulting to `0`
- `hitPoints: null` when required data is missing

## Notes

This PR focuses only on basic hit point calculation.

It does not yet include:

- damage tracking
- healing
- temporary HP updates
- death saves
- class-specific HP features
- feats or item effects that modify HP