### PR TITLE
feat: add character saving throw calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Response fields:
 - `armorClass`
 - `weaponAttacks`
 - `hitPoints`
+- `savingThrows`
 - `currency`
 - `skillProficiencies`
 - `abilityScoreRules`
@@ -386,6 +387,7 @@ Response fields:
 - `armorClass`
 - `weaponAttacks`
 - `hitPoints`
+- `savingThrows`
 - `currency`
 - `abilityScoreRules`
 - `classDetails`
@@ -403,6 +405,8 @@ Returns:
 `weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
 
 `hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
+
+`savingThrows` is derived from class saving throw proficiencies, character level, and resolved ability modifiers. It is returned as an empty array until class details and ability modifiers are available; when calculated, it is ordered as `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`.
 
 ### `PATCH /api/characters/{id}`
 
@@ -769,6 +773,68 @@ Character detail:
     "conModifier": 1,
     "calculation": "6 + 1"
   },
+  "savingThrows": [
+    {
+      "ability": "STR",
+      "isProficient": false,
+      "abilityModifier": -1,
+      "proficiencyBonus": 0,
+      "bonus": 0,
+      "total": -1,
+      "sources": [{ "type": "abilityModifier", "value": -1 }]
+    },
+    {
+      "ability": "DEX",
+      "isProficient": false,
+      "abilityModifier": 2,
+      "proficiencyBonus": 0,
+      "bonus": 0,
+      "total": 2,
+      "sources": [{ "type": "abilityModifier", "value": 2 }]
+    },
+    {
+      "ability": "CON",
+      "isProficient": false,
+      "abilityModifier": 1,
+      "proficiencyBonus": 0,
+      "bonus": 0,
+      "total": 1,
+      "sources": [{ "type": "abilityModifier", "value": 1 }]
+    },
+    {
+      "ability": "INT",
+      "isProficient": true,
+      "abilityModifier": 3,
+      "proficiencyBonus": 2,
+      "bonus": 0,
+      "total": 5,
+      "sources": [
+        { "type": "abilityModifier", "value": 3 },
+        { "type": "classProficiency", "value": 2 }
+      ]
+    },
+    {
+      "ability": "WIS",
+      "isProficient": true,
+      "abilityModifier": 1,
+      "proficiencyBonus": 2,
+      "bonus": 0,
+      "total": 3,
+      "sources": [
+        { "type": "abilityModifier", "value": 1 },
+        { "type": "classProficiency", "value": 2 }
+      ]
+    },
+    {
+      "ability": "CHA",
+      "isProficient": false,
+      "abilityModifier": 0,
+      "proficiencyBonus": 0,
+      "bonus": 0,
+      "total": 0,
+      "sources": [{ "type": "abilityModifier", "value": 0 }]
+    }
+  ],
   "currency": {
     "cp": 0,
     "sp": 0,

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, hit point calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated hit points, calculated skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated hit points, saving throws, skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -125,6 +125,7 @@ export const apiResources: ApiResource[] = [
       'armorClass',
       'weaponAttacks',
       'hitPoints',
+      'savingThrows',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -139,6 +140,7 @@ export const apiResources: ApiResource[] = [
       'armorClass',
       'weaponAttacks',
       'hitPoints',
+      'savingThrows',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -174,5 +176,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes calculated armor class, weapon attacks, and hit points',
+  'Character detail now includes calculated armor class, weapon attacks, hit points, and saving throws',
 ];

--- a/app/lib/character-saving-throws.ts
+++ b/app/lib/character-saving-throws.ts
@@ -1,0 +1,79 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterClassDetails,
+  CharacterSavingThrow,
+  CharacterSavingThrowSource,
+} from '@/app/types/character';
+import { Attributeshortname } from '@/app/types/attribute';
+
+const ABILITY_SCORE_KEYS: Attributeshortname[] = [
+  'STR',
+  'DEX',
+  'CON',
+  'INT',
+  'WIS',
+  'CHA',
+];
+
+function getProficiencyBonus(level: number): number {
+  if (level >= 17) {
+    return 6;
+  }
+
+  if (level >= 13) {
+    return 5;
+  }
+
+  if (level >= 9) {
+    return 4;
+  }
+
+  if (level >= 5) {
+    return 3;
+  }
+
+  return 2;
+}
+
+export function getCharacterSavingThrows(
+  classDetails: CharacterClassDetails | null,
+  level: number,
+  abilityModifiers: CharacterAbilityModifiers | null,
+): CharacterSavingThrow[] {
+  if (!classDetails || !abilityModifiers) {
+    return [];
+  }
+
+  const proficientSavingThrows = new Set(classDetails.savingThrows);
+  const characterProficiencyBonus = getProficiencyBonus(level);
+
+  return ABILITY_SCORE_KEYS.map((ability) => {
+    const isProficient = proficientSavingThrows.has(ability);
+    const abilityModifier = abilityModifiers[ability];
+    const proficiencyBonus = isProficient ? characterProficiencyBonus : 0;
+    const bonus = 0;
+    const sources: CharacterSavingThrowSource[] = [
+      {
+        type: 'abilityModifier',
+        value: abilityModifier,
+      },
+    ];
+
+    if (isProficient) {
+      sources.push({
+        type: 'classProficiency',
+        value: proficiencyBonus,
+      });
+    }
+
+    return {
+      ability,
+      isProficient,
+      abilityModifier,
+      proficiencyBonus,
+      bonus,
+      total: abilityModifier + proficiencyBonus + bonus,
+      sources,
+    };
+  });
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -19,6 +19,7 @@ import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getCharacterArmorClass } from './character-armor-class';
 import { getCharacterHitPoints } from './character-hit-points';
+import { getCharacterSavingThrows } from './character-saving-throws';
 import { getCharacterWeaponAttacks } from './character-weapon-attacks';
 import { getSql } from './db';
 
@@ -620,6 +621,11 @@ export async function formatCharacterResponse(character: {
     formattedCharacter.level,
     abilityModifiers,
   );
+  const savingThrows = getCharacterSavingThrows(
+    classDetails,
+    formattedCharacter.level,
+    abilityModifiers,
+  );
 
   return {
     ...formattedCharacter,
@@ -630,6 +636,7 @@ export async function formatCharacterResponse(character: {
     armorClass,
     weaponAttacks,
     hitPoints,
+    savingThrows,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -115,6 +115,21 @@ export interface CharacterHitPoints {
   calculation: string;
 }
 
+export interface CharacterSavingThrowSource {
+  type: 'abilityModifier' | 'classProficiency' | 'bonus';
+  value: number;
+}
+
+export interface CharacterSavingThrow {
+  ability: Attributeshortname;
+  isProficient: boolean;
+  abilityModifier: number;
+  proficiencyBonus: number;
+  bonus: number;
+  total: number;
+  sources: CharacterSavingThrowSource[];
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -189,6 +204,7 @@ export interface CharacterResponseBody {
   armorClass: CharacterArmorClass;
   weaponAttacks: CharacterWeaponAttack[];
   hitPoints: CharacterHitPoints | null;
+  savingThrows: CharacterSavingThrow[];
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.14.0
+  version: 1.15.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -16,7 +16,7 @@ info:
     - Classes list and detail
     - Spells list and detail
     - Species list and detail
-    - Character management, deletion, equipment flows, ability score flows, character skill flows, and character spell flows
+    - Character management, deletion, equipment flows, ability score flows, calculated combat stats, character skill flows, and character spell flows
 
 servers:
   - url: http://localhost:3000
@@ -1073,6 +1073,7 @@ paths:
                       value: 10
                 weaponAttacks: []
                 hitPoints: null
+                savingThrows: []
                 currency: null
                 skillProficiencies: []
                 abilityScoreRules: null
@@ -1119,6 +1120,7 @@ paths:
         - `armorClass`
         - `weaponAttacks`
         - `hitPoints`
+        - `savingThrows`
         - `currency`
         - `skillProficiencies`
         - `abilityScoreRules`
@@ -1131,6 +1133,8 @@ paths:
         `weaponAttacks` is derived from currently equipped weapons, class weapon proficiencies, character level, and resolved ability modifiers. If no weapon is equipped, it is returned as an empty array.
 
         `hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
+
+        `savingThrows` is derived from class saving throw proficiencies, character level, and resolved ability modifiers. It is returned as an empty array until class details and ability modifiers are available; when calculated, it is ordered as `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`.
       security:
         - bearerAuth: []
       parameters:
@@ -1221,6 +1225,65 @@ paths:
                   hitDie: 6
                   conModifier: 1
                   calculation: 6 + 1
+                savingThrows:
+                  - ability: STR
+                    isProficient: false
+                    abilityModifier: -1
+                    proficiencyBonus: 0
+                    bonus: 0
+                    total: -1
+                    sources:
+                      - type: abilityModifier
+                        value: -1
+                  - ability: DEX
+                    isProficient: false
+                    abilityModifier: 2
+                    proficiencyBonus: 0
+                    bonus: 0
+                    total: 2
+                    sources:
+                      - type: abilityModifier
+                        value: 2
+                  - ability: CON
+                    isProficient: false
+                    abilityModifier: 1
+                    proficiencyBonus: 0
+                    bonus: 0
+                    total: 1
+                    sources:
+                      - type: abilityModifier
+                        value: 1
+                  - ability: INT
+                    isProficient: true
+                    abilityModifier: 3
+                    proficiencyBonus: 2
+                    bonus: 0
+                    total: 5
+                    sources:
+                      - type: abilityModifier
+                        value: 3
+                      - type: classProficiency
+                        value: 2
+                  - ability: WIS
+                    isProficient: true
+                    abilityModifier: 1
+                    proficiencyBonus: 2
+                    bonus: 0
+                    total: 3
+                    sources:
+                      - type: abilityModifier
+                        value: 1
+                      - type: classProficiency
+                        value: 2
+                  - ability: CHA
+                    isProficient: false
+                    abilityModifier: 0
+                    proficiencyBonus: 0
+                    bonus: 0
+                    total: 0
+                    sources:
+                      - type: abilityModifier
+                        value: 0
                 currency:
                   cp: 0
                   sp: 0
@@ -3542,6 +3605,56 @@ components:
           type: string
           example: 6 + 1
 
+    CharacterSavingThrowSource:
+      type: object
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          enum:
+            - abilityModifier
+            - classProficiency
+            - bonus
+          example: abilityModifier
+        value:
+          type: integer
+          example: 3
+
+    CharacterSavingThrow:
+      type: object
+      required:
+        - ability
+        - isProficient
+        - abilityModifier
+        - proficiencyBonus
+        - bonus
+        - total
+        - sources
+      properties:
+        ability:
+          $ref: '#/components/schemas/AttributeShortname'
+        isProficient:
+          type: boolean
+          example: true
+        abilityModifier:
+          type: integer
+          example: 3
+        proficiencyBonus:
+          type: integer
+          example: 2
+        bonus:
+          type: integer
+          example: 0
+        total:
+          type: integer
+          example: 5
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterSavingThrowSource'
+
     CharacterAbilityScoreBonusChoice:
       type: object
       required:
@@ -3834,6 +3947,7 @@ components:
         - armorClass
         - weaponAttacks
         - hitPoints
+        - savingThrows
         - currency
         - skillProficiencies
         - abilityScoreRules
@@ -3889,6 +4003,10 @@ components:
           nullable: true
           allOf:
             - $ref: '#/components/schemas/CharacterHitPoints'
+        savingThrows:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterSavingThrow'
         currency:
           nullable: true
           allOf:

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -80,6 +80,15 @@ const gimliAbilityScores: CharacterAbilityScores = {
   CHA: 10,
 };
 
+const yenneferAbilityScores: CharacterAbilityScores = {
+  STR: 8,
+  DEX: 14,
+  CON: 15,
+  INT: 12,
+  WIS: 10,
+  CHA: 15,
+};
+
 const barbarianAbilityBonuses: CharacterAbilityScores = {
   STR: 2,
   DEX: 0,
@@ -134,6 +143,15 @@ const gimliAbilityBonuses: CharacterAbilityScores = {
   CHA: 0,
 };
 
+const yenneferAbilityBonuses: CharacterAbilityScores = {
+  STR: 0,
+  DEX: 0,
+  CON: 0,
+  INT: 0,
+  WIS: 1,
+  CHA: 2,
+};
+
 const barbarianAbilityScoresInput: CharacterAbilityScoresInput = {
   base: barbarianAbilityScores,
   bonuses: barbarianAbilityBonuses,
@@ -162,6 +180,11 @@ const drizztAbilityScoresInput: CharacterAbilityScoresInput = {
 const gimliAbilityScoresInput: CharacterAbilityScoresInput = {
   base: gimliAbilityScores,
   bonuses: gimliAbilityBonuses,
+};
+
+const yenneferAbilityScoresInput: CharacterAbilityScoresInput = {
+  base: yenneferAbilityScores,
+  bonuses: yenneferAbilityBonuses,
 };
 
 const patchedCurrency: CharacterCurrency = {
@@ -292,6 +315,15 @@ const fighterHitPoints: CharacterHitPoints = {
   hitDie: 10,
   conModifier: 2,
   calculation: '10 + 2',
+};
+
+const sorcererHitPoints: CharacterHitPoints = {
+  max: 8,
+  current: 8,
+  temporary: 0,
+  hitDie: 6,
+  conModifier: 2,
+  calculation: '6 + 2',
 };
 
 const barbarianSkillProficiencies: SkillName[] = [
@@ -443,6 +475,9 @@ test.describe(
         null,
       );
       await charactersAssert.validateHitPoints(createdCharacter.hitPoints, null);
+      await test.step('Validate draft character has no saving throws', async () => {
+        expect(createdCharacter.savingThrows).toEqual([]);
+      });
       await charactersAssert.validateClassDetailsPresence(
         createdCharacter.classDetails ?? null,
         false,
@@ -559,6 +594,12 @@ test.describe(
         null,
       );
       await charactersAssert.validateHitPoints(updatedCharacter.hitPoints, null);
+      await test.step(
+        'Validate character without scores has no saving throws',
+        async () => {
+          expect(updatedCharacter.savingThrows).toEqual([]);
+        },
+      );
       await charactersAssert.validateClassDetailsPresence(
         updatedCharacter.classDetails ?? null,
         true,
@@ -1204,6 +1245,31 @@ test.describe(
         finalCharacter.hitPoints,
         barbarianHitPoints,
       );
+      await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 5,
+      });
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'CON',
+        isProficient: true,
+        abilityModifier: 2,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 4,
+      });
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 1,
+        proficiencyBonus: 0,
+        bonus: 0,
+        total: 1,
+      });
       await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
         name: 'Greataxe',
         attackType: 'melee',
@@ -1333,6 +1399,12 @@ test.describe(
       await charactersAssert.validateMissingFields(character.missingFields, []);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateHitPoints(character.hitPoints, null);
+      await test.step(
+        'Validate monk without scores has no saving throws',
+        async () => {
+          expect(character.savingThrows).toEqual([]);
+        },
+      );
       await charactersAssert.validateCurrency(character.currency, acolyteCurrency);
       await charactersAssert.validateAbilityScoreRules(
         character.abilityScoreRules,
@@ -1987,6 +2059,31 @@ test.describe(
         character.hitPoints,
         paladinHitPoints,
       );
+      await charactersAssert.validateSavingThrowOrder(character.savingThrows);
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'WIS',
+        isProficient: true,
+        abilityModifier: 1,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 3,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'CHA',
+        isProficient: true,
+        abilityModifier: 2,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 4,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 0,
+        proficiencyBonus: 0,
+        bonus: 0,
+        total: 0,
+      });
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         name: 'Longsword',
         attackType: 'melee',
@@ -3004,6 +3101,31 @@ test.describe(
         finalCharacter.hitPoints,
         wizardHitPoints,
       );
+      await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'INT',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 5,
+      });
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'WIS',
+        isProficient: true,
+        abilityModifier: 1,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 3,
+      });
+      await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
+        ability: 'STR',
+        isProficient: false,
+        abilityModifier: -1,
+        proficiencyBonus: 0,
+        bonus: 0,
+        total: -1,
+      });
       await charactersAssert.validateWeaponAttack(finalCharacter.weaponAttacks, {
         name: 'Quarterstaff',
         attackType: 'melee',
@@ -3566,6 +3688,128 @@ test.describe(
 );
 
 test.describe(
+  'Characters API - Yennefer The Sorcerer Saving Throws Flow',
+  { tag: ['@characters', '@saving-throws', '@sorcerer', '@human'] },
+  () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let authToken: string;
+  let createdCharacterId: number;
+  let createdCharacterName: string;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Yennefer The Sorcerer For Saving Throws',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      createdCharacterName = `Yennefer The Sorcerer ${Date.now()}`;
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: createdCharacterName,
+          classId: 10,
+          speciesId: 7,
+          backgroundId: 1,
+          level: 1,
+          abilityScores: yenneferAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+      createdCharacterId = character.id;
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateName(character.name, createdCharacterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 10);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateLevel(character.level, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        yenneferAbilityScores,
+        yenneferAbilityBonuses,
+      );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        sorcererHitPoints,
+      );
+    },
+  );
+
+  test(
+    'Get Yennefer Sorcerer Saving Throws',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterDetail(
+        createdCharacterId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateId(character.id, createdCharacterId);
+      await charactersAssert.validateName(character.name, createdCharacterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 10);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        yenneferAbilityScores,
+        yenneferAbilityBonuses,
+      );
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        sorcererHitPoints,
+      );
+      await charactersAssert.validateSavingThrowOrder(character.savingThrows);
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'CON',
+        isProficient: true,
+        abilityModifier: 2,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 4,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'CHA',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 5,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 2,
+        proficiencyBonus: 0,
+        bonus: 0,
+        total: 2,
+      });
+    },
+  );
+  },
+);
+
+test.describe(
   'Characters API - Gimli The Fighter Equipment Flow',
   { tag: ['@characters', '@equipment', '@fighter', '@dwarf'] },
   () => {
@@ -3822,6 +4066,31 @@ test.describe(
         character.hitPoints,
         fighterHitPoints,
       );
+      await charactersAssert.validateSavingThrowOrder(character.savingThrows);
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'STR',
+        isProficient: true,
+        abilityModifier: 3,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 5,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'CON',
+        isProficient: true,
+        abilityModifier: 2,
+        proficiencyBonus: 2,
+        bonus: 0,
+        total: 4,
+      });
+      await charactersAssert.validateSavingThrow(character.savingThrows, {
+        ability: 'DEX',
+        isProficient: false,
+        abilityModifier: 1,
+        proficiencyBonus: 0,
+        bonus: 0,
+        total: 1,
+      });
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         equipmentId: greataxeEquipmentId,
         name: 'Greataxe',

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -9,6 +9,7 @@ import {
   CharacterEquipmentResponseBody,
   CharacterHitPoints,
   CharacterListItem,
+  CharacterSavingThrow,
   CharacterSkillItem,
   CharacterSpellOptionsResponseBody,
   CharacterSpellSelectionResponseBody,
@@ -567,6 +568,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('armorClass');
       expect(character).toHaveProperty('weaponAttacks');
       expect(character).toHaveProperty('hitPoints');
+      expect(character).toHaveProperty('savingThrows');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -602,6 +604,7 @@ export class CharactersAssert {
       expect(
         character.hitPoints === null || typeof character.hitPoints === 'object',
       ).toBe(true);
+      expect(Array.isArray(character.savingThrows)).toBe(true);
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -653,6 +656,8 @@ export class CharactersAssert {
     if (character.hitPoints) {
       await this.validateHitPointsSchema(character.hitPoints);
     }
+
+    await this.validateSavingThrowsSchema(character.savingThrows);
 
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
@@ -944,6 +949,104 @@ export class CharactersAssert {
     if (hitPoints) {
       await this.validateHitPointsSchema(hitPoints);
     }
+  }
+
+  async validateSavingThrowsSchema(savingThrows: CharacterSavingThrow[]) {
+    await test.step('Validate saving throws schema', async () => {
+      expect(Array.isArray(savingThrows)).toBe(true);
+    });
+
+    for (const savingThrow of savingThrows) {
+      await test.step(
+        `Validate saving throw schema for ${savingThrow.ability}`,
+        async () => {
+          expect(savingThrow).toHaveProperty('ability');
+          expect(savingThrow).toHaveProperty('isProficient');
+          expect(savingThrow).toHaveProperty('abilityModifier');
+          expect(savingThrow).toHaveProperty('proficiencyBonus');
+          expect(savingThrow).toHaveProperty('bonus');
+          expect(savingThrow).toHaveProperty('total');
+          expect(savingThrow).toHaveProperty('sources');
+
+          expect(typeof savingThrow.ability).toBe('string');
+          expect(typeof savingThrow.isProficient).toBe('boolean');
+          expect(typeof savingThrow.abilityModifier).toBe('number');
+          expect(typeof savingThrow.proficiencyBonus).toBe('number');
+          expect(typeof savingThrow.bonus).toBe('number');
+          expect(typeof savingThrow.total).toBe('number');
+          expect(Array.isArray(savingThrow.sources)).toBe(true);
+        },
+      );
+
+      for (const source of savingThrow.sources) {
+        await test.step(
+          `Validate saving throw source schema for ${savingThrow.ability}`,
+          async () => {
+            expect(source).toHaveProperty('type');
+            expect(source).toHaveProperty('value');
+
+            expect(['abilityModifier', 'classProficiency', 'bonus']).toContain(
+              source.type,
+            );
+            expect(typeof source.value).toBe('number');
+          },
+        );
+      }
+    }
+  }
+
+  async validateSavingThrowOrder(savingThrows: CharacterSavingThrow[]) {
+    await test.step('Validate Saving Throw Order', async () => {
+      expect(savingThrows.map((savingThrow) => savingThrow.ability)).toEqual([
+        'STR',
+        'DEX',
+        'CON',
+        'INT',
+        'WIS',
+        'CHA',
+      ]);
+    });
+  }
+
+  async validateSavingThrow(
+    savingThrows: CharacterSavingThrow[],
+    expectedSavingThrow: Omit<CharacterSavingThrow, 'sources'>,
+  ) {
+    await test.step(
+      `Validate saving throw for ${expectedSavingThrow.ability}`,
+      async () => {
+        const savingThrow = savingThrows.find(
+          (item) => item.ability === expectedSavingThrow.ability,
+        );
+
+        expect(savingThrow).toBeDefined();
+        expect(savingThrow).toMatchObject(expectedSavingThrow);
+        expect(savingThrow?.total).toBe(
+          expectedSavingThrow.abilityModifier +
+            expectedSavingThrow.proficiencyBonus +
+            expectedSavingThrow.bonus,
+        );
+        expect(savingThrow?.sources).toEqual(
+          expect.arrayContaining([
+            {
+              type: 'abilityModifier',
+              value: expectedSavingThrow.abilityModifier,
+            },
+          ]),
+        );
+
+        if (expectedSavingThrow.isProficient) {
+          expect(savingThrow?.sources).toEqual(
+            expect.arrayContaining([
+              {
+                type: 'classProficiency',
+                value: expectedSavingThrow.proficiencyBonus,
+              },
+            ]),
+          );
+        }
+      },
+    );
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR adds `savingThrows` calculation to character detail responses.

Saving throws are derived from the character’s ability modifiers, proficiency bonus, and class saving throw proficiencies.

## What Changed

- added `savingThrows` to `GET /api/characters/[id]`
- calculated one saving throw entry for each ability: `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`
- used `abilityModifiers` as the base value
- used `classDetails.savingThrows` to determine class proficiency
- added proficiency bonus only for class-proficient saving throws
- added `bonus` and `sources` fields to support future saving throw modifiers
- returned saving throws in a stable ability order
- added shared saving throw helper logic
- updated character response types and API resource metadata
- expanded automated tests and reusable assertions for saving throw scenarios
- updated OpenAPI and README documentation

## API Behavior

The character detail response now includes a `savingThrows` array.

Example:

```json
{
  "savingThrows": [
    {
      "ability": "STR",
      "isProficient": true,
      "abilityModifier": 3,
      "proficiencyBonus": 2,
      "bonus": 0,
      "total": 5,
      "sources": [
        {
          "type": "abilityModifier",
          "value": 3
        },
        {
          "type": "classProficiency",
          "value": 2
        }
      ]
    },
    {
      "ability": "DEX",
      "isProficient": false,
      "abilityModifier": 2,
      "proficiencyBonus": 0,
      "bonus": 0,
      "total": 2,
      "sources": [
        {
          "type": "abilityModifier",
          "value": 2
        }
      ]
    }
  ]
}
```

## Calculation Rules

For this first version:

- one entry is generated for each ability
- ability modifier is always included as the base source
- class saving throw proficiencies come from `classDetails.savingThrows`
- proficiency bonus is added only when the class grants proficiency for that ability
- `bonus` is currently `0`
- `total = abilityModifier + proficiencyBonus + bonus`
- results are ordered as `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`

## Why

The character sheet already supports:

- ability scores
- ability modifiers
- proficiency bonus
- class details
- armor class
- weapon attacks
- hit points

Adding saving throws is a natural next step toward a more complete RPG character sheet.

## Testing

This PR includes coverage for:

- saving throw schema validation
- saving throw ordering
- class-proficient saving throws
- non-proficient saving throws
- total calculation
- source attribution for ability modifier and class proficiency

## Notes

This PR focuses only on class-based saving throw calculation.

It does not yet include:

- magic item bonuses
- temporary bonuses
- advantage/disadvantage
- class features that modify saving throws
- feats
- conditions
- spell effects such as Bless or Resistance