### PR TITLE
feat: add character initiative calculation

### DIFF
--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, initiative, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated armor class, derived weapon attacks, calculated hit points, saving throws, skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated initiative, armor class, derived weapon attacks, hit points, saving throws, skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -126,6 +126,7 @@ export const apiResources: ApiResource[] = [
       'weaponAttacks',
       'hitPoints',
       'savingThrows',
+      'initiative',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -141,6 +142,7 @@ export const apiResources: ApiResource[] = [
       'weaponAttacks',
       'hitPoints',
       'savingThrows',
+      'initiative',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -176,5 +178,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes calculated armor class, weapon attacks, hit points, and saving throws',
+  'Character detail now includes initiative, armor class, weapon attacks, hit points, and saving throws',
 ];

--- a/app/lib/character-initiative.ts
+++ b/app/lib/character-initiative.ts
@@ -1,0 +1,29 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterInitiative,
+} from '@/app/types/character';
+
+export function getCharacterInitiative(
+  abilityModifiers: CharacterAbilityModifiers | null,
+): CharacterInitiative | null {
+  if (!abilityModifiers) {
+    return null;
+  }
+
+  const abilityModifier = abilityModifiers.DEX;
+  const bonus = 0;
+
+  return {
+    ability: 'DEX',
+    abilityModifier,
+    bonus,
+    total: abilityModifier + bonus,
+    sources: [
+      {
+        type: 'abilityModifier',
+        ability: 'DEX',
+        value: abilityModifier,
+      },
+    ],
+  };
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -19,6 +19,7 @@ import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getCharacterArmorClass } from './character-armor-class';
 import { getCharacterHitPoints } from './character-hit-points';
+import { getCharacterInitiative } from './character-initiative';
 import { getCharacterSavingThrows } from './character-saving-throws';
 import { getCharacterWeaponAttacks } from './character-weapon-attacks';
 import { getSql } from './db';
@@ -626,6 +627,7 @@ export async function formatCharacterResponse(character: {
     formattedCharacter.level,
     abilityModifiers,
   );
+  const initiative = getCharacterInitiative(abilityModifiers);
 
   return {
     ...formattedCharacter,
@@ -637,6 +639,7 @@ export async function formatCharacterResponse(character: {
     weaponAttacks,
     hitPoints,
     savingThrows,
+    initiative,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -130,6 +130,20 @@ export interface CharacterSavingThrow {
   sources: CharacterSavingThrowSource[];
 }
 
+export interface CharacterInitiativeSource {
+  type: 'abilityModifier' | 'bonus';
+  ability?: Attributeshortname;
+  value: number;
+}
+
+export interface CharacterInitiative {
+  ability: 'DEX';
+  abilityModifier: number;
+  bonus: number;
+  total: number;
+  sources: CharacterInitiativeSource[];
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -205,6 +219,7 @@ export interface CharacterResponseBody {
   weaponAttacks: CharacterWeaponAttack[];
   hitPoints: CharacterHitPoints | null;
   savingThrows: CharacterSavingThrow[];
+  initiative: CharacterInitiative | null;
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -475,6 +475,7 @@ test.describe(
         null,
       );
       await charactersAssert.validateHitPoints(createdCharacter.hitPoints, null);
+      await charactersAssert.validateInitiative(createdCharacter.initiative, null);
       await test.step('Validate draft character has no saving throws', async () => {
         expect(createdCharacter.savingThrows).toEqual([]);
       });
@@ -594,6 +595,7 @@ test.describe(
         null,
       );
       await charactersAssert.validateHitPoints(updatedCharacter.hitPoints, null);
+      await charactersAssert.validateInitiative(updatedCharacter.initiative, null);
       await test.step(
         'Validate character without scores has no saving throws',
         async () => {
@@ -1245,6 +1247,12 @@ test.describe(
         finalCharacter.hitPoints,
         barbarianHitPoints,
       );
+      await charactersAssert.validateInitiative(finalCharacter.initiative, {
+        ability: 'DEX',
+        abilityModifier: 1,
+        bonus: 0,
+        total: 1,
+      });
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'STR',
@@ -1399,6 +1407,7 @@ test.describe(
       await charactersAssert.validateMissingFields(character.missingFields, []);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateHitPoints(character.hitPoints, null);
+      await charactersAssert.validateInitiative(character.initiative, null);
       await test.step(
         'Validate monk without scores has no saving throws',
         async () => {
@@ -1529,6 +1538,12 @@ test.describe(
         character.hitPoints,
         monkHitPoints,
       );
+      await charactersAssert.validateInitiative(character.initiative, {
+        ability: 'DEX',
+        abilityModifier: 3,
+        bonus: 0,
+        total: 3,
+      });
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         name: 'Quarterstaff',
         attackType: 'melee',
@@ -2059,6 +2074,12 @@ test.describe(
         character.hitPoints,
         paladinHitPoints,
       );
+      await charactersAssert.validateInitiative(character.initiative, {
+        ability: 'DEX',
+        abilityModifier: 0,
+        bonus: 0,
+        total: 0,
+      });
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
         ability: 'WIS',
@@ -3101,6 +3122,12 @@ test.describe(
         finalCharacter.hitPoints,
         wizardHitPoints,
       );
+      await charactersAssert.validateInitiative(finalCharacter.initiative, {
+        ability: 'DEX',
+        abilityModifier: 2,
+        bonus: 0,
+        total: 2,
+      });
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'INT',
@@ -3779,6 +3806,12 @@ test.describe(
         character.hitPoints,
         sorcererHitPoints,
       );
+      await charactersAssert.validateInitiative(character.initiative, {
+        ability: 'DEX',
+        abilityModifier: 2,
+        bonus: 0,
+        total: 2,
+      });
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
         ability: 'CON',
@@ -4066,6 +4099,12 @@ test.describe(
         character.hitPoints,
         fighterHitPoints,
       );
+      await charactersAssert.validateInitiative(character.initiative, {
+        ability: 'DEX',
+        abilityModifier: 1,
+        bonus: 0,
+        total: 1,
+      });
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
         ability: 'STR',

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -8,6 +8,7 @@ import {
   CharacterClassDetails,
   CharacterEquipmentResponseBody,
   CharacterHitPoints,
+  CharacterInitiative,
   CharacterListItem,
   CharacterSavingThrow,
   CharacterSkillItem,
@@ -569,6 +570,7 @@ export class CharactersAssert {
       expect(character).toHaveProperty('weaponAttacks');
       expect(character).toHaveProperty('hitPoints');
       expect(character).toHaveProperty('savingThrows');
+      expect(character).toHaveProperty('initiative');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -605,6 +607,9 @@ export class CharactersAssert {
         character.hitPoints === null || typeof character.hitPoints === 'object',
       ).toBe(true);
       expect(Array.isArray(character.savingThrows)).toBe(true);
+      expect(
+        character.initiative === null || typeof character.initiative === 'object',
+      ).toBe(true);
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -659,6 +664,10 @@ export class CharactersAssert {
 
     await this.validateSavingThrowsSchema(character.savingThrows);
 
+    if (character.initiative) {
+      await this.validateInitiativeSchema(character.initiative);
+    }
+
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
     }
@@ -668,6 +677,7 @@ export class CharactersAssert {
       async () => {
         if (character.abilityScores === null) {
           expect(character.abilityModifiers).toBeNull();
+          expect(character.initiative).toBeNull();
 
           return;
         }
@@ -676,6 +686,12 @@ export class CharactersAssert {
         expect(character.abilityModifiers).toEqual(
           this.createAbilityModifiers(character.abilityScores.final),
         );
+        expect(character.initiative).not.toBeNull();
+        expect(character.initiative?.abilityModifier).toBe(
+          character.abilityModifiers?.DEX,
+        );
+        expect(character.initiative?.bonus).toBe(0);
+        expect(character.initiative?.total).toBe(character.abilityModifiers?.DEX);
       },
     );
 
@@ -1047,6 +1063,69 @@ export class CharactersAssert {
         }
       },
     );
+  }
+
+  async validateInitiativeSchema(initiative: CharacterInitiative) {
+    await test.step('Validate initiative schema', async () => {
+      expect(initiative).toHaveProperty('ability');
+      expect(initiative).toHaveProperty('abilityModifier');
+      expect(initiative).toHaveProperty('bonus');
+      expect(initiative).toHaveProperty('total');
+      expect(initiative).toHaveProperty('sources');
+
+      expect(initiative.ability).toBe('DEX');
+      expect(typeof initiative.abilityModifier).toBe('number');
+      expect(typeof initiative.bonus).toBe('number');
+      expect(typeof initiative.total).toBe('number');
+      expect(Array.isArray(initiative.sources)).toBe(true);
+    });
+
+    for (const source of initiative.sources) {
+      await test.step('Validate initiative source schema', async () => {
+        expect(source).toHaveProperty('type');
+        expect(source).toHaveProperty('value');
+
+        expect(['abilityModifier', 'bonus']).toContain(source.type);
+        expect(typeof source.value).toBe('number');
+
+        if (source.type === 'abilityModifier') {
+          expect(source).toHaveProperty('ability');
+          expect(source.ability).toBe('DEX');
+        }
+      });
+    }
+  }
+
+  async validateInitiative(
+    initiative: CharacterResponseBody['initiative'],
+    expectedInitiative: Omit<CharacterInitiative, 'sources'> | null,
+  ) {
+    await test.step('Validate initiative', async () => {
+      if (expectedInitiative === null) {
+        expect(initiative).toBeNull();
+
+        return;
+      }
+
+      expect(initiative).not.toBeNull();
+      expect(initiative).toMatchObject(expectedInitiative);
+      expect(initiative?.total).toBe(
+        expectedInitiative.abilityModifier + expectedInitiative.bonus,
+      );
+      expect(initiative?.sources).toEqual(
+        expect.arrayContaining([
+          {
+            type: 'abilityModifier',
+            ability: 'DEX',
+            value: expectedInitiative.abilityModifier,
+          },
+        ]),
+      );
+    });
+
+    if (initiative) {
+      await this.validateInitiativeSchema(initiative);
+    }
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR adds `initiative` calculation to character detail responses.

Initiative is derived from the character’s Dexterity modifier and exposed as a new block in `GET /api/characters/[id]`.

## What Changed

- added `initiative` to character detail responses
- calculated initiative from `abilityModifiers.DEX`
- set `bonus` to `0` for this first version
- added `sources` to explain the calculation
- returned `initiative: null` when ability modifiers are missing
- added shared initiative helper logic
- updated character response types and API resource metadata
- expanded automated tests and reusable assertions for initiative scenarios

## API Behavior

The character detail response now includes an `initiative` block when ability modifiers are available.

Example:

```json
{
  "initiative": {
    "ability": "DEX",
    "abilityModifier": 2,
    "bonus": 0,
    "total": 2,
    "sources": [
      {
        "type": "abilityModifier",
        "ability": "DEX",
        "value": 2
      }
    ]
  }
}
```

If required data is missing, the response returns:

```json
{
  "initiative": null
}
```

## Calculation Rules

For this first version:

- `abilityModifier` comes from `abilityModifiers.DEX`
- `bonus` is `0`
- `total = abilityModifier + bonus`
- `sources` includes the DEX ability modifier source

## Why

The character sheet already supports:

- ability scores
- ability modifiers
- saving throws
- skills
- armor class
- hit points
- weapon attacks

Adding initiative is a small but useful step toward a more complete combat-ready character sheet.

## Testing

This PR includes coverage for:

- initiative schema validation
- initiative calculation from DEX modifier
- default `bonus = 0`
- `total = abilityModifier + bonus`
- `sources` attribution
- `initiative: null` when ability modifiers are missing

## Notes

This PR focuses only on basic initiative calculation.

It does not yet include:

- feat bonuses
- class feature bonuses
- species trait bonuses
- magic item bonuses
- temporary bonuses
- advantage/disadvantage
- turn order
- encounter tracking