### PR TITLE
feat: add character derived stats summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ Response fields:
 - `weaponAttacks`
 - `hitPoints`
 - `savingThrows`
+- `initiative`
+- `passivePerception`
+- `movement`
+- `inventoryWeight`
 - `currency`
 - `skillProficiencies`
 - `abilityScoreRules`
@@ -388,6 +392,10 @@ Response fields:
 - `weaponAttacks`
 - `hitPoints`
 - `savingThrows`
+- `initiative`
+- `passivePerception`
+- `movement`
+- `inventoryWeight`
 - `currency`
 - `abilityScoreRules`
 - `classDetails`
@@ -407,6 +415,14 @@ Returns:
 `hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
 
 `savingThrows` is derived from class saving throw proficiencies, character level, and resolved ability modifiers. It is returned as an empty array until class details and ability modifiers are available; when calculated, it is ordered as `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`.
+
+`initiative` is derived from the resolved DEX modifier plus the current static bonus (`0`). It is returned as `null` until ability modifiers are available.
+
+`passivePerception` is derived from the calculated Perception skill total. Its current formula is `10 + skillModifier + bonus`, with `bonus` currently `0`. It is returned as `null` until ability modifiers are available.
+
+`movement` is derived from `speciesDetails.speed` and currently uses `ft` as the unit. It is returned as `null` until species details with a numeric speed are available.
+
+`inventoryWeight` is derived from character equipment rows with a non-null equipment weight. Each source uses `equipment.weight * quantity`; when the character has no weighted equipment, it returns `{ "total": 0, "unit": "lb", "sources": [] }`.
 
 ### `PATCH /api/characters/{id}`
 
@@ -835,6 +851,43 @@ Character detail:
       "sources": [{ "type": "abilityModifier", "value": 0 }]
     }
   ],
+  "initiative": {
+    "ability": "DEX",
+    "abilityModifier": 2,
+    "bonus": 0,
+    "total": 2,
+    "sources": [{ "type": "abilityModifier", "ability": "DEX", "value": 2 }]
+  },
+  "passivePerception": {
+    "skill": "Perception",
+    "ability": "WIS",
+    "base": 10,
+    "skillModifier": 1,
+    "bonus": 0,
+    "total": 11,
+    "sources": [
+      { "type": "base", "value": 10 },
+      { "type": "skillModifier", "value": 1 }
+    ]
+  },
+  "movement": {
+    "baseSpeed": 30,
+    "unit": "ft",
+    "sources": [{ "type": "species", "name": "Human", "value": 30 }]
+  },
+  "inventoryWeight": {
+    "total": 2,
+    "unit": "lb",
+    "sources": [
+      {
+        "equipmentId": 42,
+        "name": "Shortbow",
+        "quantity": 1,
+        "weight": 2,
+        "total": 2
+      }
+    ]
+  },
   "currency": {
     "cp": 0,
     "sp": 0,

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, initiative, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, initiative, passive perception, movement, inventory weight, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated initiative, armor class, derived weapon attacks, hit points, saving throws, skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated initiative, passive perception, movement, inventory weight, armor class, derived weapon attacks, hit points, saving throws, skill totals, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -127,6 +127,9 @@ export const apiResources: ApiResource[] = [
       'hitPoints',
       'savingThrows',
       'initiative',
+      'passivePerception',
+      'movement',
+      'inventoryWeight',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -143,6 +146,9 @@ export const apiResources: ApiResource[] = [
       'hitPoints',
       'savingThrows',
       'initiative',
+      'passivePerception',
+      'movement',
+      'inventoryWeight',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -178,5 +184,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes initiative, armor class, weapon attacks, hit points, and saving throws',
+  'Character detail now includes initiative, passive perception, movement, inventory weight, armor class, weapon attacks, hit points, and saving throws',
 ];

--- a/app/lib/character-derived-stats.ts
+++ b/app/lib/character-derived-stats.ts
@@ -1,0 +1,101 @@
+import {
+  CharacterInventoryWeight,
+  CharacterMovement,
+  CharacterPassivePerception,
+  CharacterSkillItem,
+} from '@/app/types/character';
+import { SpeciesDetail } from '@/app/types/species';
+import { getSql } from './db';
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+export function getCharacterPassivePerception(
+  skills: CharacterSkillItem[],
+): CharacterPassivePerception | null {
+  const perception = skills.find((skill) => skill.name === 'Perception');
+
+  if (!perception) {
+    return null;
+  }
+
+  const base = 10;
+  const bonus = 0;
+
+  return {
+    skill: 'Perception',
+    ability: 'WIS',
+    base,
+    skillModifier: perception.total,
+    bonus,
+    total: base + perception.total + bonus,
+    sources: [
+      {
+        type: 'base',
+        value: base,
+      },
+      {
+        type: 'skillModifier',
+        value: perception.total,
+      },
+    ],
+  };
+}
+
+export function getCharacterMovement(
+  speciesDetails: SpeciesDetail | null,
+): CharacterMovement | null {
+  if (!speciesDetails || typeof speciesDetails.speed !== 'number') {
+    return null;
+  }
+
+  return {
+    baseSpeed: speciesDetails.speed,
+    unit: 'ft',
+    sources: [
+      {
+        type: 'species',
+        name: speciesDetails.name,
+        value: speciesDetails.speed,
+      },
+    ],
+  };
+}
+
+export async function getCharacterInventoryWeight(
+  characterId: number,
+): Promise<CharacterInventoryWeight> {
+  const sql = getSql();
+  const equipmentRows = await sql`
+    SELECT
+      equipment.id,
+      equipment.name,
+      equipment.weight,
+      characterequipment.quantity
+    FROM characterequipment
+    INNER JOIN equipment ON equipment.id = characterequipment.equipmentid
+    WHERE characterequipment.characterid = ${characterId}
+      AND equipment.weight IS NOT NULL
+    ORDER BY characterequipment.id
+  `;
+
+  const sources = equipmentRows.map((item) => {
+    const weight = toNumber(item.weight);
+    const quantity = toNumber(item.quantity);
+
+    return {
+      equipmentId: toNumber(item.id),
+      name: item.name,
+      quantity,
+      weight,
+      total: weight * quantity,
+    };
+  });
+
+  return {
+    total: sources.reduce((sum, item) => sum + item.total, 0),
+    unit: 'lb',
+    sources,
+  };
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -18,6 +18,11 @@ import { BackgroundDetail } from '@/app/types/background';
 import { SpeciesDetail, SpeciesTrait } from '@/app/types/species';
 import { SKILL_NAMES, SkillName } from '@/app/types/skill';
 import { getCharacterArmorClass } from './character-armor-class';
+import {
+  getCharacterInventoryWeight,
+  getCharacterMovement,
+  getCharacterPassivePerception,
+} from './character-derived-stats';
 import { getCharacterHitPoints } from './character-hit-points';
 import { getCharacterInitiative } from './character-initiative';
 import { getCharacterSavingThrows } from './character-saving-throws';
@@ -628,6 +633,18 @@ export async function formatCharacterResponse(character: {
     abilityModifiers,
   );
   const initiative = getCharacterInitiative(abilityModifiers);
+  const skills = getCharacterSkillItems(
+    formattedCharacter.level,
+    abilityModifiers,
+    formattedCharacter.skillProficiencies,
+  );
+  const passivePerception = abilityModifiers
+    ? getCharacterPassivePerception(skills)
+    : null;
+  const movement = getCharacterMovement(speciesDetails);
+  const inventoryWeight = await getCharacterInventoryWeight(
+    formattedCharacter.id,
+  );
 
   return {
     ...formattedCharacter,
@@ -640,6 +657,9 @@ export async function formatCharacterResponse(character: {
     hitPoints,
     savingThrows,
     initiative,
+    passivePerception,
+    movement,
+    inventoryWeight,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,
@@ -647,6 +667,51 @@ export async function formatCharacterResponse(character: {
     speciesDetails,
     backgroundDetails,
   };
+}
+
+function getCharacterSkillItems(
+  level: number,
+  abilityModifiers: CharacterAbilityModifiers | null,
+  skillProficiencies: SkillName[],
+) {
+  const proficiencyBonus = getProficiencyBonus(level);
+  const proficientSkills = new Set(skillProficiencies);
+  const skillAbilityMap: Record<SkillName, Attributeshortname> = {
+    Acrobatics: 'DEX',
+    'Animal Handling': 'WIS',
+    Arcana: 'INT',
+    Athletics: 'STR',
+    Deception: 'CHA',
+    History: 'INT',
+    Insight: 'WIS',
+    Intimidation: 'CHA',
+    Investigation: 'INT',
+    Medicine: 'WIS',
+    Nature: 'INT',
+    Perception: 'WIS',
+    Performance: 'CHA',
+    Persuasion: 'CHA',
+    Religion: 'INT',
+    'Sleight of Hand': 'DEX',
+    Stealth: 'DEX',
+    Survival: 'WIS',
+  };
+
+  return SKILL_NAMES.map((name) => {
+    const ability = skillAbilityMap[name];
+    const isProficient = proficientSkills.has(name);
+    const abilityModifier = abilityModifiers?.[ability] ?? 0;
+    const appliedProficiencyBonus = isProficient ? proficiencyBonus : 0;
+
+    return {
+      name,
+      ability,
+      isProficient,
+      abilityModifier,
+      proficiencyBonus: appliedProficiencyBonus,
+      total: abilityModifier + appliedProficiencyBonus,
+    };
+  });
 }
 
 

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -144,6 +144,47 @@ export interface CharacterInitiative {
   sources: CharacterInitiativeSource[];
 }
 
+export interface CharacterPassivePerceptionSource {
+  type: 'base' | 'skillModifier' | 'bonus';
+  value: number;
+}
+
+export interface CharacterPassivePerception {
+  skill: 'Perception';
+  ability: 'WIS';
+  base: number;
+  skillModifier: number;
+  bonus: number;
+  total: number;
+  sources: CharacterPassivePerceptionSource[];
+}
+
+export interface CharacterMovementSource {
+  type: 'species';
+  name: string;
+  value: number;
+}
+
+export interface CharacterMovement {
+  baseSpeed: number;
+  unit: 'ft';
+  sources: CharacterMovementSource[];
+}
+
+export interface CharacterInventoryWeightSource {
+  equipmentId: number;
+  name: string;
+  quantity: number;
+  weight: number;
+  total: number;
+}
+
+export interface CharacterInventoryWeight {
+  total: number;
+  unit: 'lb';
+  sources: CharacterInventoryWeightSource[];
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -220,6 +261,9 @@ export interface CharacterResponseBody {
   hitPoints: CharacterHitPoints | null;
   savingThrows: CharacterSavingThrow[];
   initiative: CharacterInitiative | null;
+  passivePerception: CharacterPassivePerception | null;
+  movement: CharacterMovement | null;
+  inventoryWeight: CharacterInventoryWeight;
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.15.0
+  version: 1.16.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -16,7 +16,7 @@ info:
     - Classes list and detail
     - Spells list and detail
     - Species list and detail
-    - Character management, deletion, equipment flows, ability score flows, calculated combat stats, character skill flows, and character spell flows
+    - Character management, deletion, equipment flows, ability score flows, derived stats summary, character skill flows, and character spell flows
 
 servers:
   - url: http://localhost:3000
@@ -42,7 +42,7 @@ tags:
   - name: Species
     description: Species list and species detail endpoints.
   - name: Characters
-    description: Protected character management, deletion, equipment tracking, and derived ability, skill, and spell endpoints.
+    description: Protected character management, deletion, equipment tracking, derived stats summary, and derived ability, skill, and spell endpoints.
 
 x-tagGroups:
   - name: Access
@@ -1074,6 +1074,13 @@ paths:
                 weaponAttacks: []
                 hitPoints: null
                 savingThrows: []
+                initiative: null
+                passivePerception: null
+                movement: null
+                inventoryWeight:
+                  total: 0
+                  unit: lb
+                  sources: []
                 currency: null
                 skillProficiencies: []
                 abilityScoreRules: null
@@ -1121,6 +1128,10 @@ paths:
         - `weaponAttacks`
         - `hitPoints`
         - `savingThrows`
+        - `initiative`
+        - `passivePerception`
+        - `movement`
+        - `inventoryWeight`
         - `currency`
         - `skillProficiencies`
         - `abilityScoreRules`
@@ -1135,6 +1146,14 @@ paths:
         `hitPoints` is derived from the character's class hit die, level, and resolved CON modifier. It is returned as `null` until class details and ability modifiers are available; when calculated, `current` starts equal to `max` and `temporary` starts at `0`.
 
         `savingThrows` is derived from class saving throw proficiencies, character level, and resolved ability modifiers. It is returned as an empty array until class details and ability modifiers are available; when calculated, it is ordered as `STR`, `DEX`, `CON`, `INT`, `WIS`, `CHA`.
+
+        `initiative` is derived from the resolved DEX modifier plus the current static bonus (`0`). It is returned as `null` until ability modifiers are available.
+
+        `passivePerception` is derived from the calculated Perception skill total. Its current formula is `10 + skillModifier + bonus`, with `bonus` currently `0`. It is returned as `null` until ability modifiers are available.
+
+        `movement` is derived from `speciesDetails.speed` and currently uses `ft` as the unit. It is returned as `null` until species details with a numeric speed are available.
+
+        `inventoryWeight` is derived from character equipment rows with a non-null equipment weight. Each source uses `equipment.weight * quantity`; when the character has no weighted equipment, it returns `{ "total": 0, "unit": "lb", "sources": [] }`.
       security:
         - bearerAuth: []
       parameters:
@@ -1284,6 +1303,43 @@ paths:
                     sources:
                       - type: abilityModifier
                         value: 0
+                initiative:
+                  ability: DEX
+                  abilityModifier: 2
+                  bonus: 0
+                  total: 2
+                  sources:
+                    - type: abilityModifier
+                      ability: DEX
+                      value: 2
+                passivePerception:
+                  skill: Perception
+                  ability: WIS
+                  base: 10
+                  skillModifier: 1
+                  bonus: 0
+                  total: 11
+                  sources:
+                    - type: base
+                      value: 10
+                    - type: skillModifier
+                      value: 1
+                movement:
+                  baseSpeed: 30
+                  unit: ft
+                  sources:
+                    - type: species
+                      name: Human
+                      value: 30
+                inventoryWeight:
+                  total: 2
+                  unit: lb
+                  sources:
+                    - equipmentId: 42
+                      name: Shortbow
+                      quantity: 1
+                      weight: 2
+                      total: 2
                 currency:
                   cp: 0
                   sp: 0
@@ -3655,6 +3711,193 @@ components:
           items:
             $ref: '#/components/schemas/CharacterSavingThrowSource'
 
+    CharacterInitiativeSource:
+      type: object
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          enum:
+            - abilityModifier
+            - bonus
+          example: abilityModifier
+        ability:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AttributeShortname'
+        value:
+          type: integer
+          example: 2
+
+    CharacterInitiative:
+      type: object
+      required:
+        - ability
+        - abilityModifier
+        - bonus
+        - total
+        - sources
+      properties:
+        ability:
+          type: string
+          enum:
+            - DEX
+          example: DEX
+        abilityModifier:
+          type: integer
+          example: 2
+        bonus:
+          type: integer
+          example: 0
+        total:
+          type: integer
+          example: 2
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterInitiativeSource'
+
+    CharacterPassivePerceptionSource:
+      type: object
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          enum:
+            - base
+            - skillModifier
+            - bonus
+          example: skillModifier
+        value:
+          type: integer
+          example: 1
+
+    CharacterPassivePerception:
+      type: object
+      required:
+        - skill
+        - ability
+        - base
+        - skillModifier
+        - bonus
+        - total
+        - sources
+      properties:
+        skill:
+          type: string
+          enum:
+            - Perception
+          example: Perception
+        ability:
+          type: string
+          enum:
+            - WIS
+          example: WIS
+        base:
+          type: integer
+          example: 10
+        skillModifier:
+          type: integer
+          example: 1
+        bonus:
+          type: integer
+          example: 0
+        total:
+          type: integer
+          example: 11
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterPassivePerceptionSource'
+
+    CharacterMovementSource:
+      type: object
+      required:
+        - type
+        - name
+        - value
+      properties:
+        type:
+          type: string
+          enum:
+            - species
+          example: species
+        name:
+          type: string
+          example: Human
+        value:
+          type: integer
+          example: 30
+
+    CharacterMovement:
+      type: object
+      required:
+        - baseSpeed
+        - unit
+        - sources
+      properties:
+        baseSpeed:
+          type: integer
+          example: 30
+        unit:
+          type: string
+          enum:
+            - ft
+          example: ft
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterMovementSource'
+
+    CharacterInventoryWeightSource:
+      type: object
+      required:
+        - equipmentId
+        - name
+        - quantity
+        - weight
+        - total
+      properties:
+        equipmentId:
+          type: integer
+          example: 42
+        name:
+          type: string
+          example: Shortbow
+        quantity:
+          type: integer
+          example: 1
+        weight:
+          type: number
+          example: 2
+        total:
+          type: number
+          example: 2
+
+    CharacterInventoryWeight:
+      type: object
+      required:
+        - total
+        - unit
+        - sources
+      properties:
+        total:
+          type: number
+          example: 2
+        unit:
+          type: string
+          enum:
+            - lb
+          example: lb
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterInventoryWeightSource'
+
     CharacterAbilityScoreBonusChoice:
       type: object
       required:
@@ -3948,6 +4191,10 @@ components:
         - weaponAttacks
         - hitPoints
         - savingThrows
+        - initiative
+        - passivePerception
+        - movement
+        - inventoryWeight
         - currency
         - skillProficiencies
         - abilityScoreRules
@@ -4007,6 +4254,20 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CharacterSavingThrow'
+        initiative:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterInitiative'
+        passivePerception:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterPassivePerception'
+        movement:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/CharacterMovement'
+        inventoryWeight:
+          $ref: '#/components/schemas/CharacterInventoryWeight'
         currency:
           nullable: true
           allOf:

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -476,6 +476,15 @@ test.describe(
       );
       await charactersAssert.validateHitPoints(createdCharacter.hitPoints, null);
       await charactersAssert.validateInitiative(createdCharacter.initiative, null);
+      await charactersAssert.validatePassivePerception(
+        createdCharacter.passivePerception,
+        null,
+      );
+      await charactersAssert.validateMovement(createdCharacter.movement, null);
+      await charactersAssert.validateInventoryWeight(
+        createdCharacter.inventoryWeight,
+        { total: 0, sources: [] },
+      );
       await test.step('Validate draft character has no saving throws', async () => {
         expect(createdCharacter.savingThrows).toEqual([]);
       });
@@ -596,6 +605,11 @@ test.describe(
       );
       await charactersAssert.validateHitPoints(updatedCharacter.hitPoints, null);
       await charactersAssert.validateInitiative(updatedCharacter.initiative, null);
+      await charactersAssert.validatePassivePerception(
+        updatedCharacter.passivePerception,
+        null,
+      );
+      await charactersAssert.validateMovement(updatedCharacter.movement, null);
       await test.step(
         'Validate character without scores has no saving throws',
         async () => {
@@ -1253,6 +1267,31 @@ test.describe(
         bonus: 0,
         total: 1,
       });
+      await charactersAssert.validatePassivePerception(
+        finalCharacter.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 3,
+          bonus: 0,
+          total: 13,
+        },
+      );
+      await charactersAssert.validateMovement(
+        finalCharacter.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(
+        finalCharacter.inventoryWeight,
+        {
+          total: 7,
+          sources: [
+            { name: 'Greataxe', quantity: 1, weight: 7, total: 7 },
+          ],
+        },
+      );
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'STR',
@@ -1408,6 +1447,15 @@ test.describe(
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateHitPoints(character.hitPoints, null);
       await charactersAssert.validateInitiative(character.initiative, null);
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        null,
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
       await test.step(
         'Validate monk without scores has no saving throws',
         async () => {
@@ -1543,6 +1591,28 @@ test.describe(
         abilityModifier: 3,
         bonus: 0,
         total: 3,
+      });
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 3,
+          bonus: 0,
+          total: 13,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 4,
+        sources: [
+          { name: 'Quarterstaff', quantity: 1, weight: 4, total: 4 },
+        ],
       });
       await charactersAssert.validateWeaponAttack(character.weaponAttacks, {
         name: 'Quarterstaff',
@@ -2079,6 +2149,30 @@ test.describe(
         abilityModifier: 0,
         bonus: 0,
         total: 0,
+      });
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 1,
+          bonus: 0,
+          total: 11,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 64,
+        sources: [
+          { name: 'Chain Mail', quantity: 1, weight: 55, total: 55 },
+          { name: 'Longsword', quantity: 1, weight: 3, total: 3 },
+          { name: 'Shield', quantity: 1, weight: 6, total: 6 },
+        ],
       });
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
@@ -3128,6 +3222,22 @@ test.describe(
         bonus: 0,
         total: 2,
       });
+      await charactersAssert.validatePassivePerception(
+        finalCharacter.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 1,
+          bonus: 0,
+          total: 11,
+        },
+      );
+      await charactersAssert.validateMovement(
+        finalCharacter.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Elf', value: 30 },
+      );
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'INT',
@@ -3812,6 +3922,22 @@ test.describe(
         bonus: 0,
         total: 2,
       });
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 0,
+          bonus: 0,
+          total: 10,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
         ability: 'CON',
@@ -3953,6 +4079,26 @@ test.describe(
         character.hitPoints,
         fighterHitPoints,
       );
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 1,
+          bonus: 0,
+          total: 11,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Dwarf', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 0,
+        sources: [],
+      });
 
       await test.step('Validate character has no weapon attacks', async () => {
         expect(character.weaponAttacks).toEqual([]);
@@ -4104,6 +4250,32 @@ test.describe(
         abilityModifier: 1,
         bonus: 0,
         total: 1,
+      });
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 1,
+          bonus: 0,
+          total: 11,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Dwarf', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 71,
+        sources: [
+          { name: 'Greataxe', quantity: 1, weight: 7, total: 7 },
+          { name: 'Shortbow', quantity: 1, weight: 2, total: 2 },
+          { name: 'Dagger', quantity: 1, weight: 1, total: 1 },
+          { name: 'Chain Mail', quantity: 1, weight: 55, total: 55 },
+          { name: 'Shield', quantity: 1, weight: 6, total: 6 },
+        ],
       });
       await charactersAssert.validateSavingThrowOrder(character.savingThrows);
       await charactersAssert.validateSavingThrow(character.savingThrows, {
@@ -4374,6 +4546,15 @@ test.describe(
         character.hitPoints,
         fighterHitPoints,
       );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 64,
+        sources: [
+          { name: 'Shortbow', quantity: 1, weight: 2, total: 2 },
+          { name: 'Dagger', quantity: 1, weight: 1, total: 1 },
+          { name: 'Chain Mail', quantity: 1, weight: 55, total: 55 },
+          { name: 'Shield', quantity: 1, weight: 6, total: 6 },
+        ],
+      });
       await charactersAssert.validateWeaponAttackAbsent(
         character.weaponAttacks,
         'Greataxe',

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -9,7 +9,10 @@ import {
   CharacterEquipmentResponseBody,
   CharacterHitPoints,
   CharacterInitiative,
+  CharacterInventoryWeight,
   CharacterListItem,
+  CharacterMovement,
+  CharacterPassivePerception,
   CharacterSavingThrow,
   CharacterSkillItem,
   CharacterSpellOptionsResponseBody,
@@ -571,6 +574,9 @@ export class CharactersAssert {
       expect(character).toHaveProperty('hitPoints');
       expect(character).toHaveProperty('savingThrows');
       expect(character).toHaveProperty('initiative');
+      expect(character).toHaveProperty('passivePerception');
+      expect(character).toHaveProperty('movement');
+      expect(character).toHaveProperty('inventoryWeight');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -610,6 +616,14 @@ export class CharactersAssert {
       expect(
         character.initiative === null || typeof character.initiative === 'object',
       ).toBe(true);
+      expect(
+        character.passivePerception === null ||
+          typeof character.passivePerception === 'object',
+      ).toBe(true);
+      expect(
+        character.movement === null || typeof character.movement === 'object',
+      ).toBe(true);
+      expect(typeof character.inventoryWeight).toBe('object');
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -668,6 +682,16 @@ export class CharactersAssert {
       await this.validateInitiativeSchema(character.initiative);
     }
 
+    if (character.passivePerception) {
+      await this.validatePassivePerceptionSchema(character.passivePerception);
+    }
+
+    if (character.movement) {
+      await this.validateMovementSchema(character.movement);
+    }
+
+    await this.validateInventoryWeightSchema(character.inventoryWeight);
+
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
     }
@@ -678,6 +702,7 @@ export class CharactersAssert {
         if (character.abilityScores === null) {
           expect(character.abilityModifiers).toBeNull();
           expect(character.initiative).toBeNull();
+          expect(character.passivePerception).toBeNull();
 
           return;
         }
@@ -695,6 +720,18 @@ export class CharactersAssert {
       },
     );
 
+    await test.step('Validate passive perception consistency', async () => {
+      if (character.passivePerception === null) {
+        return;
+      }
+
+      expect(character.passivePerception.total).toBe(
+        character.passivePerception.base +
+          character.passivePerception.skillModifier +
+          character.passivePerception.bonus,
+      );
+    });
+
     if (character.abilityScoreRules) {
       await this.validateAbilityScoreRulesSchema(character.abilityScoreRules);
     }
@@ -705,6 +742,19 @@ export class CharactersAssert {
 
     if (character.speciesDetails) {
       await this.validateSpeciesDetailsSchema(character.speciesDetails);
+      await test.step('Validate movement consistency with species', async () => {
+        expect(character.movement).not.toBeNull();
+        expect(character.movement?.baseSpeed).toBe(character.speciesDetails?.speed);
+        expect(character.movement?.sources).toEqual(
+          expect.arrayContaining([
+            {
+              type: 'species',
+              name: character.speciesDetails?.name,
+              value: character.speciesDetails?.speed,
+            },
+          ]),
+        );
+      });
     }
 
     if (character.backgroundDetails) {
@@ -1126,6 +1176,185 @@ export class CharactersAssert {
     if (initiative) {
       await this.validateInitiativeSchema(initiative);
     }
+  }
+
+  async validatePassivePerceptionSchema(
+    passivePerception: CharacterPassivePerception,
+  ) {
+    await test.step('Validate passive perception schema', async () => {
+      expect(passivePerception).toHaveProperty('skill');
+      expect(passivePerception).toHaveProperty('ability');
+      expect(passivePerception).toHaveProperty('base');
+      expect(passivePerception).toHaveProperty('skillModifier');
+      expect(passivePerception).toHaveProperty('bonus');
+      expect(passivePerception).toHaveProperty('total');
+      expect(passivePerception).toHaveProperty('sources');
+
+      expect(passivePerception.skill).toBe('Perception');
+      expect(passivePerception.ability).toBe('WIS');
+      expect(typeof passivePerception.base).toBe('number');
+      expect(typeof passivePerception.skillModifier).toBe('number');
+      expect(typeof passivePerception.bonus).toBe('number');
+      expect(typeof passivePerception.total).toBe('number');
+      expect(Array.isArray(passivePerception.sources)).toBe(true);
+    });
+
+    for (const source of passivePerception.sources) {
+      await test.step('Validate passive perception source schema', async () => {
+        expect(source).toHaveProperty('type');
+        expect(source).toHaveProperty('value');
+
+        expect(['base', 'skillModifier', 'bonus']).toContain(source.type);
+        expect(typeof source.value).toBe('number');
+      });
+    }
+  }
+
+  async validatePassivePerception(
+    passivePerception: CharacterResponseBody['passivePerception'],
+    expectedPassivePerception:
+      | Omit<CharacterPassivePerception, 'sources'>
+      | null,
+  ) {
+    await test.step('Validate passive perception', async () => {
+      if (expectedPassivePerception === null) {
+        expect(passivePerception).toBeNull();
+
+        return;
+      }
+
+      expect(passivePerception).not.toBeNull();
+      expect(passivePerception).toMatchObject(expectedPassivePerception);
+      expect(passivePerception?.total).toBe(
+        expectedPassivePerception.base +
+          expectedPassivePerception.skillModifier +
+          expectedPassivePerception.bonus,
+      );
+      expect(passivePerception?.sources).toEqual(
+        expect.arrayContaining([
+          { type: 'base', value: expectedPassivePerception.base },
+          {
+            type: 'skillModifier',
+            value: expectedPassivePerception.skillModifier,
+          },
+        ]),
+      );
+    });
+
+    if (passivePerception) {
+      await this.validatePassivePerceptionSchema(passivePerception);
+    }
+  }
+
+  async validateMovementSchema(movement: CharacterMovement) {
+    await test.step('Validate movement schema', async () => {
+      expect(movement).toHaveProperty('baseSpeed');
+      expect(movement).toHaveProperty('unit');
+      expect(movement).toHaveProperty('sources');
+
+      expect(typeof movement.baseSpeed).toBe('number');
+      expect(movement.unit).toBe('ft');
+      expect(Array.isArray(movement.sources)).toBe(true);
+    });
+
+    for (const source of movement.sources) {
+      await test.step('Validate movement source schema', async () => {
+        expect(source).toHaveProperty('type');
+        expect(source).toHaveProperty('name');
+        expect(source).toHaveProperty('value');
+
+        expect(source.type).toBe('species');
+        expect(typeof source.name).toBe('string');
+        expect(typeof source.value).toBe('number');
+      });
+    }
+  }
+
+  async validateMovement(
+    movement: CharacterResponseBody['movement'],
+    expectedMovement: Omit<CharacterMovement, 'sources'> | null,
+    expectedSource?: CharacterMovement['sources'][number],
+  ) {
+    await test.step('Validate movement', async () => {
+      if (expectedMovement === null) {
+        expect(movement).toBeNull();
+
+        return;
+      }
+
+      expect(movement).not.toBeNull();
+      expect(movement).toMatchObject(expectedMovement);
+
+      if (expectedSource) {
+        expect(movement?.sources).toEqual(
+          expect.arrayContaining([expectedSource]),
+        );
+      }
+    });
+
+    if (movement) {
+      await this.validateMovementSchema(movement);
+    }
+  }
+
+  async validateInventoryWeightSchema(inventoryWeight: CharacterInventoryWeight) {
+    await test.step('Validate inventory weight schema', async () => {
+      expect(inventoryWeight).toHaveProperty('total');
+      expect(inventoryWeight).toHaveProperty('unit');
+      expect(inventoryWeight).toHaveProperty('sources');
+
+      expect(typeof inventoryWeight.total).toBe('number');
+      expect(inventoryWeight.unit).toBe('lb');
+      expect(Array.isArray(inventoryWeight.sources)).toBe(true);
+    });
+
+    for (const source of inventoryWeight.sources) {
+      await test.step(
+        `Validate inventory weight source schema for ${source.name}`,
+        async () => {
+          expect(source).toHaveProperty('equipmentId');
+          expect(source).toHaveProperty('name');
+          expect(source).toHaveProperty('quantity');
+          expect(source).toHaveProperty('weight');
+          expect(source).toHaveProperty('total');
+
+          expect(typeof source.equipmentId).toBe('number');
+          expect(typeof source.name).toBe('string');
+          expect(typeof source.quantity).toBe('number');
+          expect(typeof source.weight).toBe('number');
+          expect(typeof source.total).toBe('number');
+        },
+      );
+    }
+  }
+
+  async validateInventoryWeight(
+    inventoryWeight: CharacterInventoryWeight,
+    expectedInventoryWeight: {
+      total: number;
+      sources: Omit<
+        CharacterInventoryWeight['sources'][number],
+        'equipmentId'
+      >[];
+    },
+  ) {
+    await test.step('Validate inventory weight', async () => {
+      expect(inventoryWeight.total).toBe(expectedInventoryWeight.total);
+      expect(inventoryWeight.unit).toBe('lb');
+      expect(inventoryWeight.sources).toHaveLength(
+        expectedInventoryWeight.sources.length,
+      );
+
+      for (const expectedSource of expectedInventoryWeight.sources) {
+        expect(inventoryWeight.sources).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining(expectedSource),
+          ]),
+        );
+      }
+    });
+
+    await this.validateInventoryWeightSchema(inventoryWeight);
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR adds a Character Derived Stats Summary to character detail responses.

The new derived blocks are:

- `passivePerception`
- `movement`
- `inventoryWeight`

These values reuse data the API already has and make the character sheet more complete without introducing new persistence or complex gameplay rules.

## What Changed

- added `passivePerception` to `GET /api/characters/[id]`
- derived passive perception from the calculated Perception skill total
- added `movement` to character detail responses
- derived movement from `speciesDetails.speed`
- added `inventoryWeight` to character detail responses
- calculated inventory weight from character equipment quantity and item weight
- included source details for each derived block
- returned `null` when passive perception or movement cannot be calculated
- returned inventory weight as `0 lb` when no weighted equipment exists
- updated character response types and API resource metadata
- expanded automated tests and reusable assertions for derived stats
- updated OpenAPI and README documentation

## API Behavior

The character detail response now includes:

```json
{
  "passivePerception": {
    "skill": "Perception",
    "ability": "WIS",
    "base": 10,
    "skillModifier": 3,
    "bonus": 0,
    "total": 13,
    "sources": [
      { "type": "base", "value": 10 },
      { "type": "skillModifier", "value": 3 }
    ]
  },
  "movement": {
    "baseSpeed": 30,
    "unit": "ft",
    "sources": [
      {
        "type": "species",
        "name": "Human",
        "value": 30
      }
    ]
  },
  "inventoryWeight": {
    "total": 37.5,
    "unit": "lb",
    "sources": [
      {
        "equipmentId": 1,
        "name": "Longsword",
        "quantity": 1,
        "weight": 3,
        "total": 3
      }
    ]
  }
}
