### PR TITLE
feat: enhance character spellcasting details

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ Response fields:
 - `passivePerception`
 - `movement`
 - `inventoryWeight`
+- `spellcastingSummary`
+- `spellSlots`
+- `selectedSpells`
 - `currency`
 - `skillProficiencies`
 - `abilityScoreRules`
@@ -396,6 +399,9 @@ Response fields:
 - `passivePerception`
 - `movement`
 - `inventoryWeight`
+- `spellcastingSummary`
+- `spellSlots`
+- `selectedSpells`
 - `currency`
 - `abilityScoreRules`
 - `classDetails`
@@ -423,6 +429,12 @@ Returns:
 `movement` is derived from `speciesDetails.speed` and currently uses `ft` as the unit. It is returned as `null` until species details with a numeric speed are available.
 
 `inventoryWeight` is derived from character equipment rows with a non-null equipment weight. Each source uses `equipment.weight * quantity`; when the character has no weighted equipment, it returns `{ "total": 0, "unit": "lb", "sources": [] }`.
+
+`spellcastingSummary` is derived from the character class spellcasting metadata, character level, resolved spellcasting ability modifier, and selected spells. For non-casters, `canCastSpells` is `false`, spellcasting ability values are `null`, and selected spell counts are `0`.
+
+`spellSlots` is derived from class spellcasting progression and character level. It is returned as an empty array for non-casters or classes without supported slot progression; `used` currently starts at `0`, and `available` is `max - used`.
+
+`selectedSpells` contains enriched spell details for the character's selected spells, ordered by spell level and spell id. It is returned as an empty array when no spells are selected.
 
 ### `PATCH /api/characters/{id}`
 
@@ -888,6 +900,38 @@ Character detail:
       }
     ]
   },
+  "spellcastingSummary": {
+    "canCastSpells": true,
+    "ability": "INT",
+    "abilityModifier": 3,
+    "spellSaveDc": 13,
+    "spellAttackBonus": 5,
+    "selectedSpellsCount": 0,
+    "selectedCantripsCount": 1
+  },
+  "spellSlots": [
+    {
+      "level": 1,
+      "max": 2,
+      "used": 0,
+      "available": 2
+    }
+  ],
+  "selectedSpells": [
+    {
+      "id": 1,
+      "name": "Acid Splash",
+      "slug": "acid-splash",
+      "level": 0,
+      "levelLabel": "Cantrip",
+      "school": "Evocation",
+      "castingTime": "Action",
+      "range": "60 feet",
+      "components": ["V", "S"],
+      "duration": "Instantaneous",
+      "selectionType": "cantrip"
+    }
+  ],
   "currency": {
     "cp": 0,
     "sp": 0,

--- a/app/data/api-resources.ts
+++ b/app/data/api-resources.ts
@@ -108,9 +108,9 @@ export const apiResources: ApiResource[] = [
     name: 'Characters',
     slug: 'characters',
     description:
-      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, initiative, passive perception, movement, inventory weight, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spell selection, and enriched responses.',
+      'Protected character management flow with creation, updates, deletion, character equipment add/update/removal, ability score selection, armor class calculation, initiative, passive perception, movement, inventory weight, weapon attack calculation, hit point calculation, saving throw calculation, skill calculation, spellcasting summary, spell slots, spell selection, and enriched responses.',
     summary:
-      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated initiative, passive perception, movement, inventory weight, armor class, derived weapon attacks, hit points, saving throws, skill totals, and full character equipment tracking.',
+      'Introduces authenticated player-oriented workflows with richer character payloads, nested campaign context, calculated initiative, passive perception, movement, inventory weight, armor class, derived weapon attacks, hit points, saving throws, skill totals, spellcasting summary, spell slots, selected spell details, and full character equipment tracking.',
     listFields: [
       'id',
       'name',
@@ -130,6 +130,9 @@ export const apiResources: ApiResource[] = [
       'passivePerception',
       'movement',
       'inventoryWeight',
+      'spellcastingSummary',
+      'spellSlots',
+      'selectedSpells',
       'currency',
       'skillProficiencies',
       'abilityScoreRules',
@@ -149,6 +152,9 @@ export const apiResources: ApiResource[] = [
       'passivePerception',
       'movement',
       'inventoryWeight',
+      'spellcastingSummary',
+      'spellSlots',
+      'selectedSpells',
       'currency',
       'skillProficiencies',
       'equipment',
@@ -184,5 +190,5 @@ export const projectHighlights = [
   'Interactive documentation available in /docs',
   'Catalog coverage now includes equipment alongside classes, spells, species, and backgrounds',
   'Character flows now support adding, updating, and removing equipment from a character',
-  'Character detail now includes initiative, passive perception, movement, inventory weight, armor class, weapon attacks, hit points, and saving throws',
+  'Character detail now includes initiative, passive perception, movement, inventory weight, armor class, weapon attacks, hit points, saving throws, and spellcasting data',
 ];

--- a/app/lib/character-spellcasting.ts
+++ b/app/lib/character-spellcasting.ts
@@ -1,0 +1,267 @@
+import {
+  CharacterAbilityModifiers,
+  CharacterClassDetails,
+  CharacterSelectedSpellDetail,
+  CharacterSpellcastingSummary,
+  CharacterSpellSelectionType,
+  CharacterSpellSlot,
+} from '@/app/types/character';
+import { Attributeshortname } from '@/app/types/attribute';
+import { getSql } from './db';
+
+type SpellcastingConfig = {
+  ability?: unknown;
+};
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}
+
+function getProficiencyBonus(level: number): number {
+  if (level >= 17) {
+    return 6;
+  }
+
+  if (level >= 13) {
+    return 5;
+  }
+
+  if (level >= 9) {
+    return 4;
+  }
+
+  if (level >= 5) {
+    return 3;
+  }
+
+  return 2;
+}
+
+function isAttributeShortName(value: unknown): value is Attributeshortname {
+  return (
+    value === 'STR' ||
+    value === 'DEX' ||
+    value === 'CON' ||
+    value === 'INT' ||
+    value === 'WIS' ||
+    value === 'CHA'
+  );
+}
+
+function parseSpellcastingConfig(value: unknown): SpellcastingConfig | null {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as SpellcastingConfig;
+}
+
+function getSpellcastingAbility(
+  classDetails: CharacterClassDetails | null,
+): Attributeshortname | null {
+  const config = parseSpellcastingConfig(classDetails?.spellcasting);
+
+  return isAttributeShortName(config?.ability) ? config.ability : null;
+}
+
+function isCharacterSpellSelectionType(
+  value: unknown,
+): value is CharacterSpellSelectionType {
+  return value === 'known' || value === 'prepared' || value === 'cantrip';
+}
+
+function getComponents(spell: {
+  verbal: boolean;
+  somatic: boolean;
+  material: boolean;
+}): string[] {
+  const components: string[] = [];
+
+  if (spell.verbal) {
+    components.push('V');
+  }
+
+  if (spell.somatic) {
+    components.push('S');
+  }
+
+  if (spell.material) {
+    components.push('M');
+  }
+
+  return components;
+}
+
+export async function getCharacterSelectedSpellDetails(
+  characterId: number,
+): Promise<CharacterSelectedSpellDetail[]> {
+  const sql = getSql();
+  const spellRows = await sql`
+    SELECT
+      spells.id,
+      spells.name,
+      spells.slug,
+      spells.level,
+      spells.levellabel,
+      spells.school,
+      spells.castingtime,
+      spells.range,
+      spells.verbal,
+      spells.somatic,
+      spells.material,
+      spells.duration,
+      characterspells.selectiontype
+    FROM characterspells
+    INNER JOIN spells ON spells.id = characterspells.spellid
+    WHERE characterspells.characterid = ${characterId}
+    ORDER BY spells.level, spells.id
+  `;
+
+  return spellRows
+    .filter((spell) => isCharacterSpellSelectionType(spell.selectiontype))
+    .map((spell) => ({
+      id: toNumber(spell.id),
+      name: spell.name,
+      slug: spell.slug,
+      level: toNumber(spell.level),
+      levelLabel: spell.levellabel,
+      school: spell.school,
+      castingTime: spell.castingtime,
+      range: spell.range,
+      components: getComponents({
+        verbal: Boolean(spell.verbal),
+        somatic: Boolean(spell.somatic),
+        material: Boolean(spell.material),
+      }),
+      duration: spell.duration,
+      selectionType: spell.selectiontype,
+    }));
+}
+
+export function getCharacterSpellcastingSummary(
+  classDetails: CharacterClassDetails | null,
+  level: number,
+  abilityModifiers: CharacterAbilityModifiers | null,
+  selectedSpells: CharacterSelectedSpellDetail[],
+): CharacterSpellcastingSummary {
+  const canCastSpells = Boolean(classDetails?.spellcasting);
+  const ability = getSpellcastingAbility(classDetails);
+  const abilityModifier =
+    ability && abilityModifiers ? abilityModifiers[ability] : null;
+  const proficiencyBonus = getProficiencyBonus(level);
+
+  return {
+    canCastSpells,
+    ability: canCastSpells ? ability : null,
+    abilityModifier: canCastSpells ? abilityModifier : null,
+    spellSaveDc:
+      canCastSpells && abilityModifier !== null
+        ? 8 + proficiencyBonus + abilityModifier
+        : null,
+    spellAttackBonus:
+      canCastSpells && abilityModifier !== null
+        ? proficiencyBonus + abilityModifier
+        : null,
+    selectedSpellsCount: selectedSpells.filter((spell) => spell.level > 0)
+      .length,
+    selectedCantripsCount: selectedSpells.filter((spell) => spell.level === 0)
+      .length,
+  };
+}
+
+function getFullCasterSlots(level: number): Record<number, number> {
+  const table: Record<number, Record<number, number>> = {
+    1: { 1: 2 },
+    2: { 1: 3 },
+    3: { 1: 4, 2: 2 },
+    4: { 1: 4, 2: 3 },
+    5: { 1: 4, 2: 3, 3: 2 },
+    6: { 1: 4, 2: 3, 3: 3 },
+    7: { 1: 4, 2: 3, 3: 3, 4: 1 },
+    8: { 1: 4, 2: 3, 3: 3, 4: 2 },
+    9: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+    10: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+    11: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+    12: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+    13: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+    14: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+    15: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+    16: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+    17: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
+    18: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
+    19: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
+    20: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 },
+  };
+
+  return table[level] ?? {};
+}
+
+function getHalfCasterSlots(level: number): Record<number, number> {
+  const table: Record<number, Record<number, number>> = {
+    1: { 1: 2 },
+    2: { 1: 2 },
+    3: { 1: 3 },
+    4: { 1: 3 },
+    5: { 1: 4, 2: 2 },
+    6: { 1: 4, 2: 2 },
+    7: { 1: 4, 2: 3 },
+    8: { 1: 4, 2: 3 },
+    9: { 1: 4, 2: 3, 3: 2 },
+    10: { 1: 4, 2: 3, 3: 2 },
+    11: { 1: 4, 2: 3, 3: 3 },
+    12: { 1: 4, 2: 3, 3: 3 },
+    13: { 1: 4, 2: 3, 3: 3, 4: 1 },
+    14: { 1: 4, 2: 3, 3: 3, 4: 1 },
+    15: { 1: 4, 2: 3, 3: 3, 4: 2 },
+    16: { 1: 4, 2: 3, 3: 3, 4: 2 },
+    17: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+    18: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+    19: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+    20: { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  };
+
+  return table[level] ?? {};
+}
+
+function getSlotRecord(classSlug: string | null, level: number): Record<number, number> {
+  const fullCasters = new Set([
+    'bard',
+    'cleric',
+    'druid',
+    'sorcerer',
+    'wizard',
+  ]);
+  const halfCasters = new Set(['paladin', 'ranger']);
+
+  if (classSlug && fullCasters.has(classSlug)) {
+    return getFullCasterSlots(level);
+  }
+
+  if (classSlug && halfCasters.has(classSlug)) {
+    return getHalfCasterSlots(level);
+  }
+
+  return {};
+}
+
+export function getCharacterSpellSlots(
+  classDetails: CharacterClassDetails | null,
+  level: number,
+): CharacterSpellSlot[] {
+  if (!classDetails?.spellcasting) {
+    return [];
+  }
+
+  const slots = getSlotRecord(classDetails.slug, level);
+
+  return Object.entries(slots).map(([slotLevel, max]) => {
+    const used = 0;
+
+    return {
+      level: Number(slotLevel),
+      max,
+      used,
+      available: max - used,
+    };
+  });
+}

--- a/app/lib/characters.ts
+++ b/app/lib/characters.ts
@@ -26,6 +26,11 @@ import {
 import { getCharacterHitPoints } from './character-hit-points';
 import { getCharacterInitiative } from './character-initiative';
 import { getCharacterSavingThrows } from './character-saving-throws';
+import {
+  getCharacterSelectedSpellDetails,
+  getCharacterSpellcastingSummary,
+  getCharacterSpellSlots,
+} from './character-spellcasting';
 import { getCharacterWeaponAttacks } from './character-weapon-attacks';
 import { getSql } from './db';
 
@@ -633,6 +638,19 @@ export async function formatCharacterResponse(character: {
     abilityModifiers,
   );
   const initiative = getCharacterInitiative(abilityModifiers);
+  const selectedSpells = await getCharacterSelectedSpellDetails(
+    formattedCharacter.id,
+  );
+  const spellcastingSummary = getCharacterSpellcastingSummary(
+    classDetails,
+    formattedCharacter.level,
+    abilityModifiers,
+    selectedSpells,
+  );
+  const spellSlots = getCharacterSpellSlots(
+    classDetails,
+    formattedCharacter.level,
+  );
   const skills = getCharacterSkillItems(
     formattedCharacter.level,
     abilityModifiers,
@@ -660,6 +678,9 @@ export async function formatCharacterResponse(character: {
     passivePerception,
     movement,
     inventoryWeight,
+    spellcastingSummary,
+    spellSlots,
+    selectedSpells,
     currency: formattedCharacter.currency,
     skillProficiencies: formattedCharacter.skillProficiencies,
     abilityScoreRules,

--- a/app/types/character.ts
+++ b/app/types/character.ts
@@ -185,6 +185,23 @@ export interface CharacterInventoryWeight {
   sources: CharacterInventoryWeightSource[];
 }
 
+export interface CharacterSpellcastingSummary {
+  canCastSpells: boolean;
+  ability: Attributeshortname | null;
+  abilityModifier: number | null;
+  spellSaveDc: number | null;
+  spellAttackBonus: number | null;
+  selectedSpellsCount: number;
+  selectedCantripsCount: number;
+}
+
+export interface CharacterSpellSlot {
+  level: number;
+  max: number;
+  used: number;
+  available: number;
+}
+
 export interface CharacterAbilityScoreBonusChoice {
   bonus: number;
   count: number;
@@ -264,6 +281,9 @@ export interface CharacterResponseBody {
   passivePerception: CharacterPassivePerception | null;
   movement: CharacterMovement | null;
   inventoryWeight: CharacterInventoryWeight;
+  spellcastingSummary: CharacterSpellcastingSummary;
+  spellSlots: CharacterSpellSlot[];
+  selectedSpells: CharacterSelectedSpellDetail[];
   currency: CharacterCurrency | null;
   skillProficiencies: SkillName[];
   abilityScoreRules: CharacterAbilityScoreRules | null;
@@ -297,6 +317,15 @@ export interface CharacterSpellSelectionRule {
 
 export interface CharacterSelectedSpellItem extends CharacterSpellOptionItem {
   selectionType: CharacterSpellSelectionType;
+}
+
+export interface CharacterSelectedSpellDetail extends CharacterSelectedSpellItem {
+  slug: string;
+  school: string;
+  castingTime: string;
+  range: string;
+  components: string[];
+  duration: string;
 }
 
 export interface CharacterSpellSelectionResponseBody {

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.16.0
+  version: 1.17.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 
@@ -1081,6 +1081,16 @@ paths:
                   total: 0
                   unit: lb
                   sources: []
+                spellcastingSummary:
+                  canCastSpells: false
+                  ability: null
+                  abilityModifier: null
+                  spellSaveDc: null
+                  spellAttackBonus: null
+                  selectedSpellsCount: 0
+                  selectedCantripsCount: 0
+                spellSlots: []
+                selectedSpells: []
                 currency: null
                 skillProficiencies: []
                 abilityScoreRules: null
@@ -1132,6 +1142,9 @@ paths:
         - `passivePerception`
         - `movement`
         - `inventoryWeight`
+        - `spellcastingSummary`
+        - `spellSlots`
+        - `selectedSpells`
         - `currency`
         - `skillProficiencies`
         - `abilityScoreRules`
@@ -1154,6 +1167,12 @@ paths:
         `movement` is derived from `speciesDetails.speed` and currently uses `ft` as the unit. It is returned as `null` until species details with a numeric speed are available.
 
         `inventoryWeight` is derived from character equipment rows with a non-null equipment weight. Each source uses `equipment.weight * quantity`; when the character has no weighted equipment, it returns `{ "total": 0, "unit": "lb", "sources": [] }`.
+
+        `spellcastingSummary` is derived from the character class spellcasting metadata, character level, resolved spellcasting ability modifier, and selected spells. For non-casters, `canCastSpells` is `false`, spellcasting ability values are `null`, and selected spell counts are `0`.
+
+        `spellSlots` is derived from class spellcasting progression and character level. It is returned as an empty array for non-casters or classes without supported slot progression; `used` currently starts at `0`, and `available` is `max - used`.
+
+        `selectedSpells` contains enriched spell details for the character's selected spells, ordered by spell level and spell id. It is returned as an empty array when no spells are selected.
       security:
         - bearerAuth: []
       parameters:
@@ -1340,6 +1359,33 @@ paths:
                       quantity: 1
                       weight: 2
                       total: 2
+                spellcastingSummary:
+                  canCastSpells: true
+                  ability: INT
+                  abilityModifier: 3
+                  spellSaveDc: 13
+                  spellAttackBonus: 5
+                  selectedSpellsCount: 0
+                  selectedCantripsCount: 1
+                spellSlots:
+                  - level: 1
+                    max: 2
+                    used: 0
+                    available: 2
+                selectedSpells:
+                  - id: 1
+                    name: Acid Splash
+                    slug: acid-splash
+                    level: 0
+                    levelLabel: Cantrip
+                    school: Evocation
+                    castingTime: Action
+                    range: 60 feet
+                    components:
+                      - V
+                      - S
+                    duration: Instantaneous
+                    selectionType: cantrip
                 currency:
                   cp: 0
                   sp: 0
@@ -4195,6 +4241,9 @@ components:
         - passivePerception
         - movement
         - inventoryWeight
+        - spellcastingSummary
+        - spellSlots
+        - selectedSpells
         - currency
         - skillProficiencies
         - abilityScoreRules
@@ -4268,6 +4317,16 @@ components:
             - $ref: '#/components/schemas/CharacterMovement'
         inventoryWeight:
           $ref: '#/components/schemas/CharacterInventoryWeight'
+        spellcastingSummary:
+          $ref: '#/components/schemas/CharacterSpellcastingSummary'
+        spellSlots:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterSpellSlot'
+        selectedSpells:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterSelectedSpellDetail'
         currency:
           nullable: true
           allOf:
@@ -4316,6 +4375,99 @@ components:
         levelLabel:
           type: string
           example: Cantrip
+
+    CharacterSpellcastingSummary:
+      type: object
+      required:
+        - canCastSpells
+        - ability
+        - abilityModifier
+        - spellSaveDc
+        - spellAttackBonus
+        - selectedSpellsCount
+        - selectedCantripsCount
+      properties:
+        canCastSpells:
+          type: boolean
+          example: true
+        ability:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/AttributeShortname'
+        abilityModifier:
+          type: integer
+          nullable: true
+          example: 3
+        spellSaveDc:
+          type: integer
+          nullable: true
+          example: 13
+        spellAttackBonus:
+          type: integer
+          nullable: true
+          example: 5
+        selectedSpellsCount:
+          type: integer
+          example: 0
+        selectedCantripsCount:
+          type: integer
+          example: 1
+
+    CharacterSpellSlot:
+      type: object
+      required:
+        - level
+        - max
+        - used
+        - available
+      properties:
+        level:
+          type: integer
+          example: 1
+        max:
+          type: integer
+          example: 2
+        used:
+          type: integer
+          example: 0
+        available:
+          type: integer
+          example: 2
+
+    CharacterSelectedSpellDetail:
+      allOf:
+        - $ref: '#/components/schemas/CharacterSelectedSpellItem'
+        - type: object
+          required:
+            - slug
+            - school
+            - castingTime
+            - range
+            - components
+            - duration
+          properties:
+            slug:
+              type: string
+              example: acid-splash
+            school:
+              type: string
+              example: Evocation
+            castingTime:
+              type: string
+              example: Action
+            range:
+              type: string
+              example: 60 feet
+            components:
+              type: array
+              items:
+                type: string
+              example:
+                - V
+                - S
+            duration:
+              type: string
+              example: Instantaneous
 
     CharacterSkillItem:
       type: object

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -89,6 +89,15 @@ const yenneferAbilityScores: CharacterAbilityScores = {
   CHA: 15,
 };
 
+const casterCoverageAbilityScores: CharacterAbilityScores = {
+  STR: 8,
+  DEX: 14,
+  CON: 13,
+  INT: 12,
+  WIS: 15,
+  CHA: 15,
+};
+
 const barbarianAbilityBonuses: CharacterAbilityScores = {
   STR: 2,
   DEX: 0,
@@ -152,6 +161,15 @@ const yenneferAbilityBonuses: CharacterAbilityScores = {
   CHA: 2,
 };
 
+const casterCoverageAbilityBonuses: CharacterAbilityScores = {
+  STR: 0,
+  DEX: 0,
+  CON: 0,
+  INT: 0,
+  WIS: 1,
+  CHA: 2,
+};
+
 const barbarianAbilityScoresInput: CharacterAbilityScoresInput = {
   base: barbarianAbilityScores,
   bonuses: barbarianAbilityBonuses,
@@ -185,6 +203,11 @@ const gimliAbilityScoresInput: CharacterAbilityScoresInput = {
 const yenneferAbilityScoresInput: CharacterAbilityScoresInput = {
   base: yenneferAbilityScores,
   bonuses: yenneferAbilityBonuses,
+};
+
+const casterCoverageAbilityScoresInput: CharacterAbilityScoresInput = {
+  base: casterCoverageAbilityScores,
+  bonuses: casterCoverageAbilityBonuses,
 };
 
 const patchedCurrency: CharacterCurrency = {
@@ -1292,6 +1315,22 @@ test.describe(
           ],
         },
       );
+      await charactersAssert.validateSpellcastingSummary(
+        finalCharacter.spellcastingSummary,
+        {
+          canCastSpells: false,
+          ability: null,
+          abilityModifier: null,
+          spellSaveDc: null,
+          spellAttackBonus: null,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: 0,
+        },
+      );
+      await test.step('Validate barbarian has no spell slots or selected spells', async () => {
+        expect(finalCharacter.spellSlots).toEqual([]);
+        expect(finalCharacter.selectedSpells).toEqual([]);
+      });
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'STR',
@@ -3238,6 +3277,35 @@ test.describe(
         { baseSpeed: 30, unit: 'ft' },
         { type: 'species', name: 'Elf', value: 30 },
       );
+      await charactersAssert.validateSpellcastingSummary(
+        finalCharacter.spellcastingSummary,
+        {
+          canCastSpells: true,
+          ability: 'INT',
+          abilityModifier: 3,
+          spellSaveDc: 13,
+          spellAttackBonus: 5,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: selectedSpellIds.length,
+        },
+      );
+      await charactersAssert.validateSpellSlot(finalCharacter.spellSlots, {
+        level: 1,
+        max: 2,
+        used: 0,
+        available: 2,
+      });
+      await test.step('Validate wizard selected spells are enriched', async () => {
+        expect(finalCharacter.selectedSpells).toHaveLength(selectedSpellIds.length);
+        expect(finalCharacter.selectedSpells.map((spell) => spell.id)).toEqual(
+          selectedSpellIds,
+        );
+
+        for (const spell of finalCharacter.selectedSpells) {
+          expect(spell.level).toBe(0);
+          expect(spell.selectionType).toBe('cantrip');
+        }
+      });
       await charactersAssert.validateSavingThrowOrder(finalCharacter.savingThrows);
       await charactersAssert.validateSavingThrow(finalCharacter.savingThrows, {
         ability: 'INT',
@@ -3354,12 +3422,8 @@ test.describe(
   test.describe.configure({ mode: 'serial' });
 
   let authToken: string;
-  let noScoresCharacterId: number;
-  let withScoresCharacterId: number;
-  let patchScoresCharacterId: number;
-  let noCurrencyCharacterId: number;
-  let withCurrencyCharacterId: number;
-  let patchCurrencyCharacterId: number;
+  let drizztCharacterId: number;
+  let drizztCharacterName: string;
 
   test.beforeAll(async ({ request }) => {
     authToken = await issueDemoToken(request);
@@ -3387,25 +3451,26 @@ test.describe(
   }
 
   test(
-    'Create Drizzt Without Scores',
+    'Create Drizzt Without Scores And Currency',
     { tag: ['@post', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
+      drizztCharacterName = `Drizzt The Ranger ${Date.now()}`;
+
       const response = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(
-          `Drizzt The Ranger Without Scores ${Date.now()}`,
-        ),
+        buildDrizztRangerPayload(drizztCharacterName),
         authToken,
       );
 
       await charactersAssert.created(response);
 
       const character: CharacterResponseBody = await response.json();
-      noScoresCharacterId = character.id;
+      drizztCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
@@ -3414,14 +3479,14 @@ test.describe(
   );
 
   test(
-    'Get Drizzt Without Scores',
+    'Get Drizzt Without Scores And Currency',
     { tag: ['@get', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.getCharacterDetail(
-        noScoresCharacterId,
+        drizztCharacterId,
         authToken,
       );
 
@@ -3430,6 +3495,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
@@ -3438,25 +3504,26 @@ test.describe(
   );
 
   test(
-    'Create Drizzt With Scores',
-    { tag: ['@post', '@data'] },
+    'Patch Scores Drizzt',
+    { tag: ['@patch', '@data'] },
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
-      const response = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(`Drizzt The Ranger With Scores ${Date.now()}`, {
+      const response = await charactersClient.updateCharacter(
+        drizztCharacterId,
+        {
           abilityScores: drizztAbilityScoresInput,
-        }),
+        },
         authToken,
       );
 
-      await charactersAssert.created(response);
+      await charactersAssert.success(response);
 
       const character: CharacterResponseBody = await response.json();
-      withScoresCharacterId = character.id;
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
@@ -3476,7 +3543,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.getCharacterDetail(
-        withScoresCharacterId,
+        drizztCharacterId,
         authToken,
       );
 
@@ -3485,75 +3552,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateAbilityScores(
-        character.abilityScores,
-        drizztAbilityScores,
-        drizztAbilityBonuses,
-      );
-      await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Patch Scores Drizzt',
-    { tag: ['@patch', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const createResponse = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(`Drizzt The Ranger Patch Scores ${Date.now()}`),
-        authToken,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
-      patchScoresCharacterId = createdCharacter.id;
-
-      const response = await charactersClient.updateCharacter(
-        patchScoresCharacterId,
-        {
-          abilityScores: drizztAbilityScoresInput,
-        },
-        authToken,
-      );
-
-      await charactersAssert.success(response);
-
-      const character: CharacterResponseBody = await response.json();
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateAbilityScores(
-        character.abilityScores,
-        drizztAbilityScores,
-        drizztAbilityBonuses,
-      );
-      await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Get Patched Scores Drizzt',
-    { tag: ['@get', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.getCharacterDetail(
-        patchScoresCharacterId,
-        authToken,
-      );
-
-      await charactersAssert.success(response);
-
-      const character: CharacterResponseBody = await response.json();
-
-      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(
         character.abilityScores,
@@ -3573,7 +3572,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.updateCharacter(
-        patchScoresCharacterId,
+        drizztCharacterId,
         {
           abilityScores: null,
         },
@@ -3585,6 +3584,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
@@ -3600,7 +3600,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.getCharacterDetail(
-        patchScoresCharacterId,
+        drizztCharacterId,
         authToken,
       );
 
@@ -3609,107 +3609,10 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateAbilityScores(character.abilityScores, null);
       await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Create Drizzt Without Currency',
-    { tag: ['@post', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(
-          `Drizzt The Ranger Without Currency ${Date.now()}`,
-        ),
-        authToken,
-      );
-
-      await charactersAssert.created(response);
-
-      const character: CharacterResponseBody = await response.json();
-      noCurrencyCharacterId = character.id;
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Get Drizzt Without Currency',
-    { tag: ['@get', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.getCharacterDetail(
-        noCurrencyCharacterId,
-        authToken,
-      );
-
-      await charactersAssert.success(response);
-
-      const character: CharacterResponseBody = await response.json();
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateCurrency(character.currency, null);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Create Drizzt With Currency',
-    { tag: ['@post', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(`Drizzt The Ranger With Currency ${Date.now()}`, {
-          currency: soldierCurrency,
-        }),
-        authToken,
-      );
-
-      await charactersAssert.created(response);
-
-      const character: CharacterResponseBody = await response.json();
-      withCurrencyCharacterId = character.id;
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateCurrency(character.currency, soldierCurrency);
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Get Drizzt With Currency',
-    { tag: ['@get', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.getCharacterDetail(
-        withCurrencyCharacterId,
-        authToken,
-      );
-
-      await charactersAssert.success(response);
-
-      const character: CharacterResponseBody = await response.json();
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await validateDrizztRangerBuild(character);
-      await charactersAssert.validateCurrency(character.currency, soldierCurrency);
       await charactersAssert.validateStatus(character.status, 'complete');
     },
   );
@@ -3721,18 +3624,8 @@ test.describe(
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
 
-      const createResponse = await charactersClient.createCharacter(
-        buildDrizztRangerPayload(`Drizzt The Ranger Patch Currency ${Date.now()}`),
-        authToken,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
-      patchCurrencyCharacterId = createdCharacter.id;
-
       const response = await charactersClient.updateCharacter(
-        patchCurrencyCharacterId,
+        drizztCharacterId,
         {
           currency: patchedCurrency,
         },
@@ -3744,6 +3637,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, patchedCurrency);
       await charactersAssert.validateStatus(character.status, 'complete');
@@ -3758,7 +3652,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.getCharacterDetail(
-        patchCurrencyCharacterId,
+        drizztCharacterId,
         authToken,
       );
 
@@ -3767,6 +3661,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, patchedCurrency);
       await charactersAssert.validateStatus(character.status, 'complete');
@@ -3781,7 +3676,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.updateCharacter(
-        patchCurrencyCharacterId,
+        drizztCharacterId,
         {
           currency: null,
         },
@@ -3793,6 +3688,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'complete');
@@ -3807,7 +3703,7 @@ test.describe(
       const charactersAssert = new CharactersAssert();
 
       const response = await charactersClient.getCharacterDetail(
-        patchCurrencyCharacterId,
+        drizztCharacterId,
         authToken,
       );
 
@@ -3816,6 +3712,7 @@ test.describe(
       const character: CharacterResponseBody = await response.json();
 
       await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, drizztCharacterName);
       await validateDrizztRangerBuild(character);
       await charactersAssert.validateCurrency(character.currency, null);
       await charactersAssert.validateStatus(character.status, 'complete');
@@ -3969,13 +3866,284 @@ test.describe(
 );
 
 test.describe(
+  'Characters API - Scanlan The Bard Caster Coverage Flow',
+  { tag: ['@characters', '@flow', '@class-coverage', '@bard', '@human'] },
+  () => {
+  let authToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Scanlan The Bard For Caster Coverage',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const characterName = `Scanlan The Bard ${Date.now()}`;
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: characterName,
+          classId: 2,
+          speciesId: 7,
+          backgroundId: 1,
+          level: 1,
+          abilityScores: casterCoverageAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, characterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 2);
+      await charactersAssert.validateSpeciesId(character.speciesId, 7);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        casterCoverageAbilityScores,
+        casterCoverageAbilityBonuses,
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Human', value: 30 },
+      );
+      await charactersAssert.validateSpellcastingSummary(
+        character.spellcastingSummary,
+        {
+          canCastSpells: true,
+          ability: 'CHA',
+          abilityModifier: 3,
+          spellSaveDc: 13,
+          spellAttackBonus: 5,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: 0,
+        },
+      );
+    },
+  );
+  },
+);
+
+test.describe(
+  'Characters API - Pike The Cleric Caster Coverage Flow',
+  { tag: ['@characters', '@flow', '@class-coverage', '@cleric', '@dragonborn'] },
+  () => {
+  let authToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Pike The Cleric For Caster Coverage',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const characterName = `Pike The Cleric ${Date.now()}`;
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: characterName,
+          classId: 3,
+          speciesId: 1,
+          backgroundId: 1,
+          level: 1,
+          abilityScores: casterCoverageAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, characterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 3);
+      await charactersAssert.validateSpeciesId(character.speciesId, 1);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        casterCoverageAbilityScores,
+        casterCoverageAbilityBonuses,
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Dragonborn', value: 30 },
+      );
+      await charactersAssert.validateSpellcastingSummary(
+        character.spellcastingSummary,
+        {
+          canCastSpells: true,
+          ability: 'WIS',
+          abilityModifier: 3,
+          spellSaveDc: 13,
+          spellAttackBonus: 5,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: 0,
+        },
+      );
+    },
+  );
+  },
+);
+
+test.describe(
+  'Characters API - Keyleth The Druid Caster Coverage Flow',
+  { tag: ['@characters', '@flow', '@class-coverage', '@druid', '@elf'] },
+  () => {
+  let authToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Keyleth The Druid For Caster Coverage',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const characterName = `Keyleth The Druid ${Date.now()}`;
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: characterName,
+          classId: 4,
+          speciesId: 3,
+          backgroundId: 1,
+          level: 1,
+          abilityScores: casterCoverageAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, characterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 4);
+      await charactersAssert.validateSpeciesId(character.speciesId, 3);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        casterCoverageAbilityScores,
+        casterCoverageAbilityBonuses,
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Elf', value: 30 },
+      );
+      await charactersAssert.validateSpellcastingSummary(
+        character.spellcastingSummary,
+        {
+          canCastSpells: true,
+          ability: 'WIS',
+          abilityModifier: 3,
+          spellSaveDc: 13,
+          spellAttackBonus: 5,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: 0,
+        },
+      );
+    },
+  );
+  },
+);
+
+test.describe(
+  'Characters API - Elric The Warlock Caster Coverage Flow',
+  { tag: ['@characters', '@flow', '@class-coverage', '@warlock', '@orc'] },
+  () => {
+  let authToken: string;
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+  });
+
+  test(
+    'Create Elric The Warlock For Caster Coverage',
+    { tag: ['@post', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+      const characterName = `Elric The Warlock ${Date.now()}`;
+
+      const response = await charactersClient.createCharacter(
+        {
+          name: characterName,
+          classId: 11,
+          speciesId: 8,
+          backgroundId: 1,
+          level: 1,
+          abilityScores: casterCoverageAbilityScoresInput,
+        },
+        authToken,
+      );
+
+      await charactersAssert.created(response);
+
+      const character: CharacterResponseBody = await response.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateName(character.name, characterName);
+      await charactersAssert.validateStatus(character.status, 'complete');
+      await charactersAssert.validateClassId(character.classId, 11);
+      await charactersAssert.validateSpeciesId(character.speciesId, 8);
+      await charactersAssert.validateBackgroundId(character.backgroundId, 1);
+      await charactersAssert.validateMissingFields(character.missingFields, []);
+      await charactersAssert.validateAbilityScores(
+        character.abilityScores,
+        casterCoverageAbilityScores,
+        casterCoverageAbilityBonuses,
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Orc', value: 30 },
+      );
+      await charactersAssert.validateSpellcastingSummary(
+        character.spellcastingSummary,
+        {
+          canCastSpells: true,
+          ability: 'CHA',
+          abilityModifier: 3,
+          spellSaveDc: 13,
+          spellAttackBonus: 5,
+          selectedSpellsCount: 0,
+          selectedCantripsCount: 0,
+        },
+      );
+    },
+  );
+  },
+);
+
+test.describe(
   'Characters API - Gimli The Fighter Equipment Flow',
   { tag: ['@characters', '@equipment', '@fighter', '@dwarf'] },
   () => {
   test.describe.configure({ mode: 'serial' });
 
   let authToken: string;
-  let characterWithoutEquipmentId: number;
   let characterWithEquipmentId: number;
   let greataxeEquipmentId: number;
   let shortbowEquipmentId: number;
@@ -3996,115 +4164,6 @@ test.describe(
     expect(shortbow.name).toBe('Shortbow');
     shortbowEquipmentId = shortbow.id;
   });
-
-  test(
-    'Create Gimli Without Equipment',
-    { tag: ['@post', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.createCharacter(
-        {
-          name: `Gimli The Fighter Without Equipment ${Date.now()}`,
-          classId: 5,
-          speciesId: 2,
-          backgroundId: 16,
-          level: 1,
-          abilityScores: gimliAbilityScoresInput,
-        },
-        authToken,
-      );
-
-      await charactersAssert.created(response);
-
-      const character: CharacterResponseBody = await response.json();
-      characterWithoutEquipmentId = character.id;
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateClassId(character.classId, 5);
-      await charactersAssert.validateSpeciesId(character.speciesId, 2);
-      await charactersAssert.validateBackgroundId(character.backgroundId, 16);
-      await charactersAssert.validateAbilityScores(
-        character.abilityScores,
-        gimliAbilityScores,
-        gimliAbilityBonuses,
-      );
-      await charactersAssert.validateHitPoints(
-        character.hitPoints,
-        fighterHitPoints,
-      );
-      await charactersAssert.validateStatus(character.status, 'complete');
-    },
-  );
-
-  test(
-    'Get Empty Equipment',
-    { tag: ['@get', '@data'] },
-    async ({ request }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-
-      const response = await charactersClient.getCharacterEquipment(
-        characterWithoutEquipmentId,
-        authToken,
-      );
-
-      await charactersAssert.success(response);
-
-      const characterEquipment: CharacterEquipmentResponseBody =
-        await response.json();
-
-      await charactersAssert.validateCharacterEquipmentSchema(characterEquipment);
-      await charactersAssert.validateId(
-        characterEquipment.characterId,
-        characterWithoutEquipmentId,
-      );
-
-      await test.step('Validate character has no equipment', async () => {
-        expect(characterEquipment.equipment).toEqual([]);
-      });
-
-      const detailResponse = await charactersClient.getCharacterDetail(
-        characterWithoutEquipmentId,
-        authToken,
-      );
-
-      await charactersAssert.success(detailResponse);
-
-      const character: CharacterResponseBody = await detailResponse.json();
-
-      await charactersAssert.validateCharacterResponseSchema(character);
-      await charactersAssert.validateHitPoints(
-        character.hitPoints,
-        fighterHitPoints,
-      );
-      await charactersAssert.validatePassivePerception(
-        character.passivePerception,
-        {
-          skill: 'Perception',
-          ability: 'WIS',
-          base: 10,
-          skillModifier: 1,
-          bonus: 0,
-          total: 11,
-        },
-      );
-      await charactersAssert.validateMovement(
-        character.movement,
-        { baseSpeed: 30, unit: 'ft' },
-        { type: 'species', name: 'Dwarf', value: 30 },
-      );
-      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
-        total: 0,
-        sources: [],
-      });
-
-      await test.step('Validate character has no weapon attacks', async () => {
-        expect(character.weaponAttacks).toEqual([]);
-      });
-    },
-  );
 
   test(
     'Create Gimli The Fighter',
@@ -4144,6 +4203,74 @@ test.describe(
         fighterHitPoints,
       );
       await charactersAssert.validateStatus(character.status, 'complete');
+    },
+  );
+
+  test(
+    'Get Empty Equipment',
+    { tag: ['@get', '@data'] },
+    async ({ request }) => {
+      const charactersClient = new CharactersClient(request);
+      const charactersAssert = new CharactersAssert();
+
+      const response = await charactersClient.getCharacterEquipment(
+        characterWithEquipmentId,
+        authToken,
+      );
+
+      await charactersAssert.success(response);
+
+      const characterEquipment: CharacterEquipmentResponseBody =
+        await response.json();
+
+      await charactersAssert.validateCharacterEquipmentSchema(characterEquipment);
+      await charactersAssert.validateId(
+        characterEquipment.characterId,
+        characterWithEquipmentId,
+      );
+
+      await test.step('Validate character has no equipment', async () => {
+        expect(characterEquipment.equipment).toEqual([]);
+      });
+
+      const detailResponse = await charactersClient.getCharacterDetail(
+        characterWithEquipmentId,
+        authToken,
+      );
+
+      await charactersAssert.success(detailResponse);
+
+      const character: CharacterResponseBody = await detailResponse.json();
+
+      await charactersAssert.validateCharacterResponseSchema(character);
+      await charactersAssert.validateHitPoints(
+        character.hitPoints,
+        fighterHitPoints,
+      );
+      await charactersAssert.validatePassivePerception(
+        character.passivePerception,
+        {
+          skill: 'Perception',
+          ability: 'WIS',
+          base: 10,
+          skillModifier: 1,
+          bonus: 0,
+          total: 11,
+        },
+      );
+      await charactersAssert.validateMovement(
+        character.movement,
+        { baseSpeed: 30, unit: 'ft' },
+        { type: 'species', name: 'Dwarf', value: 30 },
+      );
+      await charactersAssert.validateInventoryWeight(character.inventoryWeight, {
+        total: 0,
+        sources: [],
+      });
+
+      await test.step('Validate character has no weapon attacks', async () => {
+        expect(character.weaponAttacks).toEqual([]);
+      });
     },
   );
 
@@ -4702,6 +4829,11 @@ test.describe(
   'Characters API - Geralt Of Rivia The Warlock Negative Flow',
   { tag: ['@characters', '@negative', '@warlock', '@dragonborn'] },
   () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let authToken: string;
+  let geraltCharacterId: number;
+
   const buildGeraltWarlockPayload = (
     name: string,
     payload: Partial<Omit<CharacterCreateRequestBody, 'name'>> = {},
@@ -4712,6 +4844,21 @@ test.describe(
     backgroundId: 1,
     level: 1,
     ...payload,
+  });
+
+  test.beforeAll(async ({ request }) => {
+    authToken = await issueDemoToken(request);
+
+    const charactersClient = new CharactersClient(request);
+    const createResponse = await charactersClient.createCharacter(
+      buildGeraltWarlockPayload(`Geralt Of Rivia ${Date.now()}`),
+      authToken,
+    );
+
+    expect(createResponse.status()).toBe(201);
+
+    const character: CharacterResponseBody = await createResponse.json();
+    geraltCharacterId = character.id;
   });
 
   test(
@@ -4864,9 +5011,8 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
-      const response = await charactersClient.getCharacterDetail(999999, token);
+      const response = await charactersClient.getCharacterDetail(999999, authToken);
 
       await charactersAssert.notFound(response);
 
@@ -4882,12 +5028,11 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.updateCharacter(
         999999,
         { classId: 11 },
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -4904,9 +5049,8 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
-      const response = await charactersClient.deleteCharacter(999999, token);
+      const response = await charactersClient.deleteCharacter(999999, authToken);
 
       await charactersAssert.notFound(response);
 
@@ -4922,9 +5066,11 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
-      const response = await charactersClient.getCharacterEquipment(999999, token);
+      const response = await charactersClient.getCharacterEquipment(
+        999999,
+        authToken,
+      );
 
       await charactersAssert.notFound(response);
 
@@ -4940,7 +5086,6 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.addCharacterEquipment(
         999999,
@@ -4949,7 +5094,7 @@ test.describe(
           quantity: 1,
           isEquipped: true,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -4966,7 +5111,6 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.patchCharacterEquipment(
         999999,
@@ -4974,7 +5118,7 @@ test.describe(
         {
           quantity: 1,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -4991,12 +5135,11 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.deleteCharacterEquipment(
         999999,
         1,
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -5013,27 +5156,15 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(
-          `Geralt Of Rivia Invalid Equipment ${Date.now()}`,
-        ),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.addCharacterEquipment(
-        createdCharacter.id,
+        geraltCharacterId,
         {
           equipmentId: 999999,
           quantity: 1,
           isEquipped: true,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -5050,26 +5181,14 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(
-          `Geralt Of Rivia Missing Equipment Patch ${Date.now()}`,
-        ),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.patchCharacterEquipment(
-        createdCharacter.id,
+        geraltCharacterId,
         999999,
         {
           quantity: 1,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -5089,23 +5208,11 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(
-          `Geralt Of Rivia Missing Equipment Delete ${Date.now()}`,
-        ),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.deleteCharacterEquipment(
-        createdCharacter.id,
+        geraltCharacterId,
         999999,
-        token,
+        authToken,
       );
 
       await charactersAssert.notFound(response);
@@ -5125,27 +5232,15 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(
-          `Geralt Of Rivia Invalid Equipment Payload ${Date.now()}`,
-        ),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.addCharacterEquipment(
-        createdCharacter.id,
+        geraltCharacterId,
         {
           equipmentId: 1,
           quantity: 0,
           isEquipped: true,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5165,15 +5260,14 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.patchCharacterEquipment(
-        1,
+        geraltCharacterId,
         1,
         {
           quantity: 0,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5193,13 +5287,12 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.patchCharacterEquipment(
-        1,
+        geraltCharacterId,
         1,
         {},
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5219,15 +5312,14 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.patchCharacterEquipment(
-        1,
+        geraltCharacterId,
         1,
         {
           quantity: '3',
         } as unknown as { quantity: number },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5247,7 +5339,6 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.createCharacter(
         {
@@ -5257,7 +5348,7 @@ test.describe(
           backgroundId: 1,
           level: 1,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5277,23 +5368,13 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Patch ${Date.now()}`),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const updateResponse = await charactersClient.updateCharacter(
-        createdCharacter.id,
+        geraltCharacterId,
         {
           level: 0,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(updateResponse);
@@ -5313,7 +5394,6 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.createCharacter(
         buildGeraltWarlockPayload(`Geralt Of Rivia Incomplete Scores ${Date.now()}`, {
@@ -5326,7 +5406,7 @@ test.describe(
             },
           } as unknown as CharacterAbilityScoresInput,
         }),
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5346,19 +5426,9 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Scores ${Date.now()}`),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.updateCharacter(
-        createdCharacter.id,
+        geraltCharacterId,
         {
           abilityScores: {
             base: {
@@ -5379,7 +5449,7 @@ test.describe(
             },
           } as unknown as CharacterAbilityScoresInput,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5399,7 +5469,6 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
 
       const response = await charactersClient.createCharacter(
         buildGeraltWarlockPayload(
@@ -5410,7 +5479,7 @@ test.describe(
           } as unknown as CharacterCurrency,
           },
         ),
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);
@@ -5430,19 +5499,9 @@ test.describe(
     async ({ request }) => {
       const charactersClient = new CharactersClient(request);
       const charactersAssert = new CharactersAssert();
-      const token = await issueDemoToken(request);
-
-      const createResponse = await charactersClient.createCharacter(
-        buildGeraltWarlockPayload(`Geralt Of Rivia Invalid Currency ${Date.now()}`),
-        token,
-      );
-
-      await charactersAssert.created(createResponse);
-
-      const createdCharacter: CharacterResponseBody = await createResponse.json();
 
       const response = await charactersClient.updateCharacter(
-        createdCharacter.id,
+        geraltCharacterId,
         {
           currency: {
             cp: 0,
@@ -5452,7 +5511,7 @@ test.describe(
             pp: 0,
           } as unknown as CharacterCurrency,
         },
-        token,
+        authToken,
       );
 
       await charactersAssert.badRequest(response);

--- a/tests/helpers/characters.assertions.ts
+++ b/tests/helpers/characters.assertions.ts
@@ -13,10 +13,13 @@ import {
   CharacterListItem,
   CharacterMovement,
   CharacterPassivePerception,
+  CharacterSelectedSpellDetail,
   CharacterSavingThrow,
+  CharacterSpellcastingSummary,
   CharacterSkillItem,
   CharacterSpellOptionsResponseBody,
   CharacterSpellSelectionResponseBody,
+  CharacterSpellSlot,
   CharacterResponseBody,
   CharacterStatus,
   CharacterWeaponAttack,
@@ -577,6 +580,9 @@ export class CharactersAssert {
       expect(character).toHaveProperty('passivePerception');
       expect(character).toHaveProperty('movement');
       expect(character).toHaveProperty('inventoryWeight');
+      expect(character).toHaveProperty('spellcastingSummary');
+      expect(character).toHaveProperty('spellSlots');
+      expect(character).toHaveProperty('selectedSpells');
       expect(character).toHaveProperty('currency');
       expect(character).toHaveProperty('skillProficiencies');
       expect(character).toHaveProperty('abilityScoreRules');
@@ -624,6 +630,9 @@ export class CharactersAssert {
         character.movement === null || typeof character.movement === 'object',
       ).toBe(true);
       expect(typeof character.inventoryWeight).toBe('object');
+      expect(typeof character.spellcastingSummary).toBe('object');
+      expect(Array.isArray(character.spellSlots)).toBe(true);
+      expect(Array.isArray(character.selectedSpells)).toBe(true);
       expect(
         character.currency === null || typeof character.currency === 'object',
       ).toBe(true);
@@ -691,6 +700,9 @@ export class CharactersAssert {
     }
 
     await this.validateInventoryWeightSchema(character.inventoryWeight);
+    await this.validateSpellcastingSummarySchema(character.spellcastingSummary);
+    await this.validateSpellSlotsSchema(character.spellSlots);
+    await this.validateSelectedSpellsSchema(character.selectedSpells);
 
     if (character.currency) {
       await this.validateCurrencySchema(character.currency);
@@ -1355,6 +1367,138 @@ export class CharactersAssert {
     });
 
     await this.validateInventoryWeightSchema(inventoryWeight);
+  }
+
+  async validateSpellcastingSummarySchema(
+    spellcastingSummary: CharacterSpellcastingSummary,
+  ) {
+    await test.step('Validate spellcasting summary schema', async () => {
+      expect(spellcastingSummary).toHaveProperty('canCastSpells');
+      expect(spellcastingSummary).toHaveProperty('ability');
+      expect(spellcastingSummary).toHaveProperty('abilityModifier');
+      expect(spellcastingSummary).toHaveProperty('spellSaveDc');
+      expect(spellcastingSummary).toHaveProperty('spellAttackBonus');
+      expect(spellcastingSummary).toHaveProperty('selectedSpellsCount');
+      expect(spellcastingSummary).toHaveProperty('selectedCantripsCount');
+
+      expect(typeof spellcastingSummary.canCastSpells).toBe('boolean');
+      expect(
+        spellcastingSummary.ability === null ||
+          typeof spellcastingSummary.ability === 'string',
+      ).toBe(true);
+      expect(
+        spellcastingSummary.abilityModifier === null ||
+          typeof spellcastingSummary.abilityModifier === 'number',
+      ).toBe(true);
+      expect(
+        spellcastingSummary.spellSaveDc === null ||
+          typeof spellcastingSummary.spellSaveDc === 'number',
+      ).toBe(true);
+      expect(
+        spellcastingSummary.spellAttackBonus === null ||
+          typeof spellcastingSummary.spellAttackBonus === 'number',
+      ).toBe(true);
+      expect(typeof spellcastingSummary.selectedSpellsCount).toBe('number');
+      expect(typeof spellcastingSummary.selectedCantripsCount).toBe('number');
+    });
+  }
+
+  async validateSpellcastingSummary(
+    spellcastingSummary: CharacterSpellcastingSummary,
+    expectedSummary: CharacterSpellcastingSummary,
+  ) {
+    await test.step('Validate spellcasting summary', async () => {
+      expect(spellcastingSummary).toEqual(expectedSummary);
+
+      if (
+        expectedSummary.canCastSpells &&
+        expectedSummary.abilityModifier !== null
+      ) {
+        expect(spellcastingSummary.spellSaveDc).toBe(
+          8 + 2 + expectedSummary.abilityModifier,
+        );
+        expect(spellcastingSummary.spellAttackBonus).toBe(
+          2 + expectedSummary.abilityModifier,
+        );
+      }
+    });
+
+    await this.validateSpellcastingSummarySchema(spellcastingSummary);
+  }
+
+  async validateSpellSlotsSchema(spellSlots: CharacterSpellSlot[]) {
+    await test.step('Validate spell slots schema', async () => {
+      expect(Array.isArray(spellSlots)).toBe(true);
+    });
+
+    for (const spellSlot of spellSlots) {
+      await test.step(`Validate spell slot schema for level ${spellSlot.level}`, async () => {
+        expect(spellSlot).toHaveProperty('level');
+        expect(spellSlot).toHaveProperty('max');
+        expect(spellSlot).toHaveProperty('used');
+        expect(spellSlot).toHaveProperty('available');
+
+        expect(typeof spellSlot.level).toBe('number');
+        expect(typeof spellSlot.max).toBe('number');
+        expect(typeof spellSlot.used).toBe('number');
+        expect(typeof spellSlot.available).toBe('number');
+        expect(spellSlot.available).toBe(spellSlot.max - spellSlot.used);
+      });
+    }
+  }
+
+  async validateSpellSlot(
+    spellSlots: CharacterSpellSlot[],
+    expectedSpellSlot: CharacterSpellSlot,
+  ) {
+    await test.step(`Validate spell slot level ${expectedSpellSlot.level}`, async () => {
+      expect(spellSlots).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ ...expectedSpellSlot }),
+        ]),
+      );
+      expect(expectedSpellSlot.available).toBe(
+        expectedSpellSlot.max - expectedSpellSlot.used,
+      );
+    });
+
+    await this.validateSpellSlotsSchema(spellSlots);
+  }
+
+  async validateSelectedSpellsSchema(
+    selectedSpells: CharacterSelectedSpellDetail[],
+  ) {
+    await test.step('Validate selected spells schema', async () => {
+      expect(Array.isArray(selectedSpells)).toBe(true);
+    });
+
+    for (const spell of selectedSpells) {
+      await test.step(`Validate selected spell detail schema for ${spell.name}`, async () => {
+        expect(spell).toHaveProperty('id');
+        expect(spell).toHaveProperty('name');
+        expect(spell).toHaveProperty('slug');
+        expect(spell).toHaveProperty('level');
+        expect(spell).toHaveProperty('levelLabel');
+        expect(spell).toHaveProperty('school');
+        expect(spell).toHaveProperty('castingTime');
+        expect(spell).toHaveProperty('range');
+        expect(spell).toHaveProperty('components');
+        expect(spell).toHaveProperty('duration');
+        expect(spell).toHaveProperty('selectionType');
+
+        expect(typeof spell.id).toBe('number');
+        expect(typeof spell.name).toBe('string');
+        expect(typeof spell.slug).toBe('string');
+        expect(typeof spell.level).toBe('number');
+        expect(typeof spell.levelLabel).toBe('string');
+        expect(typeof spell.school).toBe('string');
+        expect(typeof spell.castingTime).toBe('string');
+        expect(typeof spell.range).toBe('string');
+        expect(Array.isArray(spell.components)).toBe(true);
+        expect(typeof spell.duration).toBe('string');
+        expect(typeof spell.selectionType).toBe('string');
+      });
+    }
   }
 
   async validateCurrencySchema(currency: CharacterCurrency) {


### PR DESCRIPTION
## Summary

This PR enhances character spellcasting details in the Adventurers Guild API.

It adds a richer spellcasting section to character detail responses by introducing `spellcastingSummary`, `spellSlots`, and enriched `selectedSpells`.

## What Changed

- added `spellcastingSummary` to `GET /api/characters/[id]`
- calculated spell save DC from spellcasting ability modifier and proficiency bonus
- calculated spell attack bonus from spellcasting ability modifier and proficiency bonus
- included selected spell and selected cantrip counts
- added `spellSlots` derived from class spellcasting progression and character level
- returned empty spell slots for non-casters or unsupported slot progression
- enriched `selectedSpells` with display-ready spell details
- preserved existing spell selection behavior
- added shared spellcasting helper logic
- updated character response types and API resource metadata
- expanded automated tests and reusable assertions for spellcasting scenarios
- updated OpenAPI and README documentation for the new spellcasting detail fields

## API Behavior

The character detail response now includes spellcasting-focused fields.

Example:

```json
{
  "spellcastingSummary": {
    "canCastSpells": true,
    "ability": "INT",
    "abilityModifier": 3,
    "spellSaveDc": 13,
    "spellAttackBonus": 5,
    "selectedSpellsCount": 0,
    "selectedCantripsCount": 1
  },
  "spellSlots": [
    {
      "level": 1,
      "max": 2,
      "used": 0,
      "available": 2
    }
  ],
  "selectedSpells": [
    {
      "id": 1,
      "name": "Acid Splash",
      "slug": "acid-splash",
      "level": 0,
      "levelLabel": "Cantrip",
      "school": "Evocation",
      "castingTime": "Action",
      "range": "60 feet",
      "components": ["V", "S"],
      "duration": "Instantaneous",
      "selectionType": "cantrip"
    }
  ]
}
```

## Rules

For this first version:

- `canCastSpells` is based on class spellcasting metadata
- spellcasting ability comes from class spellcasting data
- ability modifier comes from the character’s resolved ability modifiers
- `spellSaveDc = 8 + proficiencyBonus + abilityModifier`
- `spellAttackBonus = proficiencyBonus + abilityModifier`
- selected spell counts are derived from the character’s selected spells
- spell slots are derived from class spellcasting progression and character level
- `used` starts at `0`
- `available = max - used`
- non-casters return `canCastSpells: false`, empty spell slots, and empty selected spells

## Why

The character sheet already supported spell options and spell selection, but the detail response did not yet provide a consolidated spellcasting view.

This change makes spellcasting characters easier to display and prepares the project for future spellcasting features such as:

- spell slot tracking
- richer spell cards
- prepared/known spell views
- spell usage
- concentration tracking

## Testing

This PR includes coverage for:

- spellcasting summary schema
- spell save DC calculation
- spell attack bonus calculation
- selected spell and cantrip counts
- spell slot structure
- non-caster behavior
- enriched selected spell display data
- preserving the existing spell selection flow

## Notes

This PR focuses on read-side spellcasting detail enrichment.

It does not yet include:

- tracking used spell slots
- casting spells
- advanced spell preparation rules
- multiclass spell slot rules
- ritual casting rules
- component consumption
- concentration tracking
- spell attack rolling
- spell damage rolling