### PR TITLE
Add backgrounds guide chapter

### DIFF
--- a/app/components/guides-accordion.tsx
+++ b/app/components/guides-accordion.tsx
@@ -3,8 +3,17 @@
 import Image from 'next/image';
 import { useState, type MouseEvent } from 'react';
 
+import { BackgroundsGuideChapter } from '@/app/components/guides/backgrounds-guide-chapter';
+import {
+  getAttributeAnchor,
+  getBackgroundAnchor,
+  getClassAnchor,
+  getSkillAnchor,
+  getSpeciesAnchor,
+} from '@/app/components/guides/background-guide-utils';
 import { apiResources } from '@/app/data/api-resources';
 import type { Attribute } from '@/app/types/attribute';
+import type { BackgroundDetail } from '@/app/types/background';
 import type { ClassDetail } from '@/app/types/class';
 import type { SkillDetail } from '@/app/types/skill';
 import type { SpeciesDetail } from '@/app/types/species';
@@ -35,6 +44,7 @@ import survivalIcon from '@/public/images/skills/survival.png';
 
 type GuidesAccordionProps = {
   attributes: Attribute[];
+  backgrounds: BackgroundDetail[];
   classes: ClassDetail[];
   skills: SkillDetail[];
   species: SpeciesDetail[];
@@ -389,30 +399,6 @@ const speciesDetailResponseFields = [
   },
 ];
 
-function getSkillAnchor(skillName: string) {
-  return `skill-${getGuideAnchorSlug(skillName)}`;
-}
-
-function getClassAnchor(className: string) {
-  return `class-${getGuideAnchorSlug(className)}`;
-}
-
-function getSpeciesAnchor(speciesName: string) {
-  return `species-${getGuideAnchorSlug(speciesName)}`;
-}
-
-function getGuideAnchorSlug(value: string) {
-  return value
-    .toLowerCase()
-    .replaceAll('&', 'and')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '');
-}
-
-function getAttributeAnchor(attributeShortname: string) {
-  return `attribute-${attributeShortname.toLowerCase()}`;
-}
-
 function splitDescriptionSentences(description: string) {
   return description
     .split(/(?<=\.)\s+/)
@@ -422,6 +408,7 @@ function splitDescriptionSentences(description: string) {
 
 export function GuidesAccordion({
   attributes,
+  backgrounds,
   classes,
   skills,
   species,
@@ -430,10 +417,12 @@ export function GuidesAccordion({
   const [isSkillsOpen, setIsSkillsOpen] = useState(false);
   const [isClassesOpen, setIsClassesOpen] = useState(false);
   const [isSpeciesOpen, setIsSpeciesOpen] = useState(false);
+  const [isBackgroundsOpen, setIsBackgroundsOpen] = useState(false);
   const [selectedAttributeIndex, setSelectedAttributeIndex] = useState(0);
   const [selectedSkillIndex, setSelectedSkillIndex] = useState(0);
   const [selectedClassIndex, setSelectedClassIndex] = useState(0);
   const [selectedSpeciesIndex, setSelectedSpeciesIndex] = useState(0);
+  const [selectedBackgroundIndex, setSelectedBackgroundIndex] = useState(0);
   const skillDetailExample =
     skills.find((skill) => skill.name === 'Athletics') ?? skills[0];
   const speciesDetailExample =
@@ -455,22 +444,16 @@ export function GuidesAccordion({
     setIsSpeciesOpen((currentValue) => !currentValue);
   }
 
+  function toggleBackgrounds() {
+    setIsBackgroundsOpen((currentValue) => !currentValue);
+  }
+
   function openSkillCard(
     event: MouseEvent<HTMLAnchorElement>,
     skillName: string,
   ) {
-    const skillIndex = skills.findIndex((skill) => skill.name === skillName);
-    const nextSkill = skills[skillIndex];
-
     event.preventDefault();
-
-    if (!nextSkill) {
-      return;
-    }
-
-    setIsSkillsOpen(true);
-    setSelectedSkillIndex(skillIndex);
-    scrollToGuideCard(getSkillAnchor(nextSkill.name));
+    openSkillByName(skillName);
   }
 
   function updateGuideCardHash(anchor: string) {
@@ -519,12 +502,15 @@ export function GuidesAccordion({
     event: MouseEvent<HTMLAnchorElement>,
     attributeShortname: string,
   ) {
+    event.preventDefault();
+    openAttributeByShortname(attributeShortname);
+  }
+
+  function openAttributeByShortname(attributeShortname: string) {
     const attributeIndex = attributes.findIndex(
       (attribute) => attribute.shortname === attributeShortname,
     );
     const nextAttribute = attributes[attributeIndex];
-
-    event.preventDefault();
 
     if (!nextAttribute) {
       return;
@@ -533,6 +519,19 @@ export function GuidesAccordion({
     setIsAttributesOpen(true);
     setSelectedAttributeIndex(attributeIndex);
     scrollToGuideCard(getAttributeAnchor(nextAttribute.shortname));
+  }
+
+  function openSkillByName(skillName: string) {
+    const skillIndex = skills.findIndex((skill) => skill.name === skillName);
+    const nextSkill = skills[skillIndex];
+
+    if (!nextSkill) {
+      return;
+    }
+
+    setIsSkillsOpen(true);
+    setSelectedSkillIndex(skillIndex);
+    scrollToGuideCard(getSkillAnchor(nextSkill.name));
   }
 
   function openChapterIndex(
@@ -588,6 +587,18 @@ export function GuidesAccordion({
         block: 'start',
       });
       updateGuideCardHash(speciesAnchor);
+    });
+  }
+
+  function scrollToBackgroundCard(backgroundName: string) {
+    window.requestAnimationFrame(() => {
+      const backgroundAnchor = getBackgroundAnchor(backgroundName);
+
+      document.getElementById(backgroundAnchor)?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'start',
+      });
+      updateGuideCardHash(backgroundAnchor);
     });
   }
 
@@ -663,6 +674,25 @@ export function GuidesAccordion({
     selectSpeciesByIndex(speciesIndex, false);
   }
 
+  function selectBackgroundByIndex(
+    backgroundIndex: number,
+    shouldScroll = true,
+  ) {
+    const nextBackground = backgrounds[backgroundIndex];
+
+    if (!nextBackground) {
+      return;
+    }
+
+    setSelectedBackgroundIndex(backgroundIndex);
+
+    if (shouldScroll) {
+      scrollToBackgroundCard(nextBackground.name);
+    } else {
+      updateGuideCardHash(getBackgroundAnchor(nextBackground.name));
+    }
+  }
+
   function openAttributesChapter() {
     setIsAttributesOpen(true);
     scrollToChapterIndex('attributes-index');
@@ -681,6 +711,11 @@ export function GuidesAccordion({
   function openSpeciesChapter() {
     setIsSpeciesOpen(true);
     scrollToChapterIndex('species-index');
+  }
+
+  function openBackgroundsChapter() {
+    setIsBackgroundsOpen(true);
+    scrollToChapterIndex('backgrounds-index');
   }
 
   function closeAttributesChapter() {
@@ -703,6 +738,11 @@ export function GuidesAccordion({
     scrollToGuideSection('species');
   }
 
+  function closeBackgroundsChapter() {
+    setIsBackgroundsOpen(false);
+    scrollToGuideSection('backgrounds');
+  }
+
   return (
     <>
       <section className="section-block guide-grimoire-cover">
@@ -722,13 +762,19 @@ export function GuidesAccordion({
             const isSkills = resource.slug === 'skills';
             const isClasses = resource.slug === 'classes';
             const isSpecies = resource.slug === 'species';
+            const isBackgrounds = resource.slug === 'backgrounds';
             const isEnabled =
-              isAttributes || isSkills || isClasses || isSpecies;
+              isAttributes ||
+              isSkills ||
+              isClasses ||
+              isSpecies ||
+              isBackgrounds;
             const isOpen =
               (isAttributes && isAttributesOpen) ||
               (isSkills && isSkillsOpen) ||
               (isClasses && isClassesOpen) ||
-              (isSpecies && isSpeciesOpen);
+              (isSpecies && isSpeciesOpen) ||
+              (isBackgrounds && isBackgroundsOpen);
 
             return (
               <button
@@ -745,7 +791,9 @@ export function GuidesAccordion({
                         ? openClassesChapter
                         : isSpecies
                           ? openSpeciesChapter
-                        : undefined
+                          : isBackgrounds
+                            ? openBackgroundsChapter
+                          : undefined
                 }
                 type="button"
               >
@@ -1914,6 +1962,19 @@ export function GuidesAccordion({
           </div>
         </div>
       </section>
+
+      <BackgroundsGuideChapter
+        attributes={attributes}
+        backgrounds={backgrounds}
+        isOpen={isBackgroundsOpen}
+        onClose={closeBackgroundsChapter}
+        onOpenAttribute={openAttributeByShortname}
+        onOpenChapterIndex={scrollToChapterIndex}
+        onOpenSkill={openSkillByName}
+        onSelectBackground={selectBackgroundByIndex}
+        onToggle={toggleBackgrounds}
+        selectedBackgroundIndex={selectedBackgroundIndex}
+      />
     </>
   );
 }

--- a/app/components/guides/background-guide-utils.ts
+++ b/app/components/guides/background-guide-utils.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import type { Attribute } from '@/app/types/attribute';
+
+export function getGuideAnchorSlug(value: string) {
+  return value
+    .toLowerCase()
+    .replaceAll('&', 'and')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+export function getSkillAnchor(skillName: string) {
+  return `skill-${getGuideAnchorSlug(skillName)}`;
+}
+
+export function getClassAnchor(className: string) {
+  return `class-${getGuideAnchorSlug(className)}`;
+}
+
+export function getSpeciesAnchor(speciesName: string) {
+  return `species-${getGuideAnchorSlug(speciesName)}`;
+}
+
+export function getBackgroundAnchor(backgroundName: string) {
+  return `background-${getGuideAnchorSlug(backgroundName)}`;
+}
+
+export function getAttributeAnchor(attributeShortname: string) {
+  return `attribute-${attributeShortname.toLowerCase()}`;
+}
+
+export function normalizeGuideReference(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export function findAttributeByReference(
+  attributes: Attribute[],
+  attributeReference: string,
+) {
+  const normalizedReference = normalizeGuideReference(attributeReference);
+
+  return attributes.find((attribute) => {
+    return (
+      normalizeGuideReference(attribute.shortname) === normalizedReference ||
+      normalizeGuideReference(attribute.name) === normalizedReference
+    );
+  });
+}
+
+export function splitEquipmentOptionItems(option: string) {
+  return option
+    .split(/\s*,\s*/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/app/components/guides/background-images.ts
+++ b/app/components/guides/background-images.ts
@@ -1,0 +1,66 @@
+export const backgroundImages: Record<string, { alt: string; src: string }> = {
+  Acolyte: {
+    alt: 'Ancient temple illuminated by candles for the Acolyte background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775648171/adventurers/backgrounds/Templo_antigo_iluminado_por_velas_kyjwpk.png',
+  },
+  Artisan: {
+    alt: 'Woodworking artisan workshop for the Artisan background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649055/adventurers/backgrounds/Oficina_de_arte_em_madeira_tlklqp.png',
+  },
+  Charlatan: {
+    alt: 'Tavern sleight-of-hand game for the Charlatan background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649153/adventurers/backgrounds/Jogo_de_sortile%CC%81gios_na_taverna_jhwtgk.png',
+  },
+  Criminal: {
+    alt: 'Narrow and shadowy medieval street for the Criminal background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649367/adventurers/backgrounds/Rua_estreita_e_sombria_medieval_xpkgoi.png',
+  },
+  Entertainer: {
+    alt: 'Medieval festival at dusk for the Entertainer background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649472/adventurers/backgrounds/Festival_medieval_ao_entardecer_ddlo7k.png',
+  },
+  Farmer: {
+    alt: 'Cozy rustic countryside scene for the Farmer background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649681/adventurers/backgrounds/Cena_acolhedora_do_campo_ru%CC%81stico_m2ke8m.png',
+  },
+  Guard: {
+    alt: 'Sentinel at dusk for the Guard background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775649819/adventurers/backgrounds/Sentinela_no_fim_da_tarde_wdc5dg.png',
+  },
+  Guide: {
+    alt: 'Camp beside a waterfall for the Guide background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650023/adventurers/backgrounds/Acampamento_a%CC%80_beira_da_cachoeira_o8tmzv.png',
+  },
+  Hermit: {
+    alt: 'Forest hermit cabin for the Hermit background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650122/adventurers/backgrounds/Cabana_do_eremita_na_floresta_xntijj.png',
+  },
+  Merchant: {
+    alt: 'Medieval market at dusk for the Merchant background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650235/adventurers/backgrounds/Mercado_medieval_ao_entardecer_sonz6l.png',
+  },
+  Noble: {
+    alt: 'Elegant ball in a grand hall for the Noble background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650520/adventurers/backgrounds/Baile_elegante_no_grandioso_sala%CC%83o_gk0f5k.png',
+  },
+  Sage: {
+    alt: 'Candlelit magical library for the Sage background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650692/adventurers/backgrounds/Biblioteca_ma%CC%81gica_iluminada_por_velas_bhpijh.png',
+  },
+  Sailor: {
+    alt: 'Sailing ship at sunset for the Sailor background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775650950/adventurers/backgrounds/Navio_a%CC%80_vela_ao_po%CC%82r_do_sol_lyiwhx.png',
+  },
+  Scribe: {
+    alt: 'Ancient writing desk by candlelight for the Scribe background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775651013/adventurers/backgrounds/Escrito%CC%81rio_antigo_a%CC%80_luz_de_velas_yp8qvs.png',
+  },
+  Soldier: {
+    alt: 'Battlefield at dusk for the Soldier background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775651067/adventurers/backgrounds/Campo_de_batalha_ao_entardecer_rfq9zj.png',
+  },
+  Wayfarer: {
+    alt: 'Shadowy street with lit lanterns for the Wayfarer background',
+    src: 'https://res.cloudinary.com/dtglidvcw/image/upload/v1775651218/adventurers/backgrounds/Rua_sombria_e_lanternas_acesas_lko0je.png',
+  },
+};

--- a/app/components/guides/background-response-fields.ts
+++ b/app/components/guides/background-response-fields.ts
@@ -1,0 +1,60 @@
+export const backgroundListResponseFields = [
+  {
+    name: 'id',
+    type: 'number',
+    description: 'Unique numeric identifier for the background.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Background name returned in the compact list response.',
+  },
+];
+
+export const backgroundDetailResponseFields = [
+  {
+    name: 'id',
+    type: 'number',
+    description: 'Unique numeric identifier for the background.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Readable background name.',
+  },
+  {
+    name: 'slug',
+    type: 'string',
+    description: 'URL-friendly identifier accepted by the detail endpoint.',
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Narrative summary of the background.',
+  },
+  {
+    name: 'abilityScores',
+    type: 'string[]',
+    description: 'Ability score options linked to this background.',
+  },
+  {
+    name: 'feat',
+    type: 'string',
+    description: 'Feat granted by the background.',
+  },
+  {
+    name: 'skillProficiencies',
+    type: 'string[]',
+    description: 'Skill proficiencies granted by the background.',
+  },
+  {
+    name: 'toolProficiency',
+    type: 'string | null',
+    description: 'Optional tool proficiency included in the background.',
+  },
+  {
+    name: 'equipmentOptions',
+    type: 'string[]',
+    description: 'Starting equipment options for the background.',
+  },
+];

--- a/app/components/guides/backgrounds-guide-chapter.tsx
+++ b/app/components/guides/backgrounds-guide-chapter.tsx
@@ -1,0 +1,418 @@
+'use client';
+
+import Image from 'next/image';
+import { type MouseEvent } from 'react';
+
+import { backgroundImages } from '@/app/components/guides/background-images';
+import { backgroundDetailResponseFields, backgroundListResponseFields } from '@/app/components/guides/background-response-fields';
+import {
+  findAttributeByReference,
+  getAttributeAnchor,
+  getBackgroundAnchor,
+  getSkillAnchor,
+  splitEquipmentOptionItems,
+} from '@/app/components/guides/background-guide-utils';
+import type { Attribute } from '@/app/types/attribute';
+import type { BackgroundDetail } from '@/app/types/background';
+
+type BackgroundsGuideChapterProps = {
+  attributes: Attribute[];
+  backgrounds: BackgroundDetail[];
+  isOpen: boolean;
+  selectedBackgroundIndex: number;
+  onToggle: () => void;
+  onClose: () => void;
+  onSelectBackground: (backgroundIndex: number, shouldScroll?: boolean) => void;
+  onOpenChapterIndex: (indexId: string) => void;
+  onOpenAttribute: (attributeShortname: string) => void;
+  onOpenSkill: (skillName: string) => void;
+};
+
+const backgroundsIndexId = 'backgrounds-index';
+
+export function BackgroundsGuideChapter({
+  attributes,
+  backgrounds,
+  isOpen,
+  selectedBackgroundIndex,
+  onToggle,
+  onClose,
+  onSelectBackground,
+  onOpenChapterIndex,
+  onOpenAttribute,
+  onOpenSkill,
+}: BackgroundsGuideChapterProps) {
+  const backgroundDetailExample = backgrounds[0];
+
+  function handleOpenBackground(
+    event: MouseEvent<HTMLAnchorElement>,
+    backgroundIndex: number,
+  ) {
+    event.preventDefault();
+    onSelectBackground(backgroundIndex, false);
+  }
+
+  function handleOpenChapterIndex(event: MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+    onOpenChapterIndex(backgroundsIndexId);
+  }
+
+  function handleOpenAttribute(
+    event: MouseEvent<HTMLAnchorElement>,
+    attributeShortname: string,
+  ) {
+    event.preventDefault();
+    onOpenAttribute(attributeShortname);
+  }
+
+  function handleOpenSkill(event: MouseEvent<HTMLAnchorElement>, skillName: string) {
+    event.preventDefault();
+    onOpenSkill(skillName);
+  }
+
+  return (
+    <section
+      aria-labelledby="backgrounds-heading"
+      className="section-block guide-accordion"
+      id="backgrounds"
+    >
+      <h2 className="guide-accordion__heading" id="backgrounds-heading">
+        <button
+          aria-controls="backgrounds-panel"
+          aria-expanded={isOpen}
+          className="guide-accordion__toggle"
+          onClick={onToggle}
+          type="button"
+        >
+          <span>
+            <span className="kicker">Fifth chapter</span>
+            <span className="guide-accordion__title">Backgrounds</span>
+            <strong aria-hidden="true">{isOpen ? 'Close' : 'Open'}</strong>
+          </span>
+        </button>
+      </h2>
+
+      <div
+        aria-hidden={!isOpen}
+        className={`guide-accordion__content${
+          isOpen ? ' guide-accordion__content--open' : ''
+        }`}
+        id="backgrounds-panel"
+        inert={!isOpen}
+        role="region"
+      >
+        <div className="guide-accordion__scroll">
+          <p className="guide-accordion__description">
+            Backgrounds frame where an adventurer comes from before their first
+            quest, combining identity, proficiencies, and starting gear.
+          </p>
+
+          <nav
+            aria-label="Backgrounds index"
+            className="guide-card-index"
+            id={backgroundsIndexId}
+          >
+            <p>Chapter index</p>
+            <div>
+              {backgrounds.map((background, backgroundIndex) => (
+                <a
+                  aria-current={
+                    backgroundIndex === selectedBackgroundIndex ? 'true' : undefined
+                  }
+                  href={`#${getBackgroundAnchor(background.name)}`}
+                  key={background.id}
+                  onClick={(event) => handleOpenBackground(event, backgroundIndex)}
+                >
+                  {background.name}
+                </a>
+              ))}
+            </div>
+          </nav>
+
+          <div className="species-guide-grid">
+            {backgrounds.map((background, backgroundIndex) => {
+              if (backgroundIndex !== selectedBackgroundIndex) {
+                return null;
+              }
+
+              const backgroundImage = backgroundImages[background.name];
+              const previousBackground = backgrounds[backgroundIndex - 1];
+              const nextBackground = backgrounds[backgroundIndex + 1];
+
+              return (
+                <article
+                  className="species-guide-card"
+                  id={getBackgroundAnchor(background.name)}
+                  key={background.id}
+                >
+                  <div
+                    className={`species-guide-card__overview${
+                      backgroundImage ? '' : ' species-guide-card__overview--text-only'
+                    }`}
+                  >
+                    {backgroundImage ? (
+                      <div className="species-guide-card__media">
+                        <Image
+                          alt={backgroundImage.alt}
+                          fill
+                          sizes="(max-width: 980px) 100vw, 40vw"
+                          src={backgroundImage.src}
+                        />
+                      </div>
+                    ) : null}
+                    <div className="species-guide-card__header">
+                      <p className="kicker">Origin and identity</p>
+                      <h3>{background.name}</h3>
+                      <p>{background.description}</p>
+                    </div>
+                  </div>
+
+                  <div className="background-guide-card__details">
+                    <p>What this background grants</p>
+                    <ul>
+                      <li>
+                        <strong>Tool proficiency</strong>
+                        <span>{background.toolProficiency ?? 'None'}</span>
+                      </li>
+                      <li>
+                        <strong>Feat</strong>
+                        <span>{background.feat}</span>
+                      </li>
+                      <li>
+                        <strong>Ability scores</strong>
+                        <div className="attribute-skill-list">
+                          {background.abilityScores.length > 0 ? (
+                            background.abilityScores.map((abilityScore) => {
+                              const attribute = findAttributeByReference(
+                                attributes,
+                                abilityScore,
+                              );
+
+                              return attribute ? (
+                                <a
+                                  className="attribute-skill-chip"
+                                  href={`#${getAttributeAnchor(attribute.shortname)}`}
+                                  key={abilityScore}
+                                  onClick={(event) =>
+                                    handleOpenAttribute(event, attribute.shortname)
+                                  }
+                                >
+                                  {attribute.name}
+                                </a>
+                              ) : (
+                                <span
+                                  className="attribute-skill-chip attribute-skill-chip--empty"
+                                  key={abilityScore}
+                                >
+                                  {abilityScore}
+                                </span>
+                              );
+                            })
+                          ) : (
+                            <span className="attribute-skill-chip attribute-skill-chip--empty">
+                              No ability score options listed.
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                      <li>
+                        <strong>Skill proficiencies</strong>
+                        <div className="attribute-skill-list">
+                          {background.skillProficiencies.length > 0 ? (
+                            background.skillProficiencies.map((skill) => (
+                              <a
+                                className="attribute-skill-chip"
+                                href={`#${getSkillAnchor(skill)}`}
+                                key={skill}
+                                onClick={(event) => handleOpenSkill(event, skill)}
+                              >
+                                {skill}
+                              </a>
+                            ))
+                          ) : (
+                            <span className="attribute-skill-chip attribute-skill-chip--empty">
+                              No skill proficiencies listed.
+                            </span>
+                          )}
+                        </div>
+                      </li>
+                      <li>
+                        <strong>Equipment options</strong>
+                        {background.equipmentOptions.length > 0 ? (
+                          <div className="background-guide-card__option-grid">
+                            {background.equipmentOptions.map((equipmentOption, optionIndex) => (
+                              <div
+                                className="background-guide-card__option-card"
+                                key={`${background.id}-option-${optionIndex}`}
+                              >
+                                <p>{`Option ${optionIndex + 1}`}</p>
+                                <ul>
+                                  {splitEquipmentOptionItems(equipmentOption).map((item) => (
+                                    <li
+                                      key={`${background.id}-option-${optionIndex}-${item}`}
+                                    >
+                                      {item}
+                                    </li>
+                                  ))}
+                                </ul>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <span>No equipment options listed.</span>
+                        )}
+                      </li>
+                    </ul>
+                  </div>
+
+                  <nav
+                    aria-label={`${background.name} navigation`}
+                    className="guide-card-navigation"
+                  >
+                    {previousBackground ? (
+                      <button
+                        aria-label={`Previous background: ${previousBackground.name}`}
+                        className="guide-card-navigation__link"
+                        onClick={() => onSelectBackground(backgroundIndex - 1)}
+                        type="button"
+                      >
+                        ←
+                      </button>
+                    ) : (
+                      <span className="guide-card-navigation__placeholder" />
+                    )}
+
+                    <a
+                      className="guide-card-back-link"
+                      href={`#${backgroundsIndexId}`}
+                      onClick={handleOpenChapterIndex}
+                    >
+                      Index
+                    </a>
+
+                    {nextBackground ? (
+                      <button
+                        aria-label={`Next background: ${nextBackground.name}`}
+                        className="guide-card-navigation__link"
+                        onClick={() => onSelectBackground(backgroundIndex + 1)}
+                        type="button"
+                      >
+                        →
+                      </button>
+                    ) : (
+                      <span className="guide-card-navigation__placeholder" />
+                    )}
+                  </nav>
+                </article>
+              );
+            })}
+          </div>
+
+          <aside className="guide-how-to-use">
+            <h3>How to use</h3>
+            <p>
+              Call <code>GET /api/backgrounds</code> to build a chapter index or
+              picker. Use <code>GET /api/backgrounds/{'{identifier}'}</code> when
+              you need the full background description, feat, proficiency
+              package, and equipment options for a specific choice.
+            </p>
+            <div className="endpoint-stack">
+              <a
+                className="endpoint-pill"
+                href="https://adventurers-guild-api.vercel.app/api/backgrounds"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GET /api/backgrounds
+              </a>
+              <a
+                className="endpoint-pill"
+                href="https://adventurers-guild-api.vercel.app/api/backgrounds/acolyte"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GET /api/backgrounds/{'{identifier}'}
+              </a>
+            </div>
+          </aside>
+
+          <section className="guide-expected-return">
+            <div className="section-heading">
+              <h3>Expected return</h3>
+              <h4>Response shapes</h4>
+              <p>
+                The list endpoint stays compact, while the detail endpoint adds
+                the gameplay fields needed to understand a background.
+              </p>
+            </div>
+
+            <div className="response-variant">
+              <div className="response-variant__heading">
+                <span>List response</span>
+                <code>GET /api/backgrounds</code>
+              </div>
+              <div className="response-field-list response-field-list--compact">
+                {backgroundListResponseFields.map((field) => (
+                  <article className="response-field-card" key={field.name}>
+                    <span>{field.name}</span>
+                    <p>{field.description}</p>
+                    <strong>{field.type}</strong>
+                  </article>
+                ))}
+              </div>
+              <div className="response-example">
+                <div className="response-example__header">
+                  <span>Example JSON</span>
+                  <code>200 OK</code>
+                </div>
+                <pre>
+                  <code>
+                    {JSON.stringify(
+                      backgrounds.map((background) => ({
+                        id: background.id,
+                        name: background.name,
+                      })),
+                      null,
+                      2,
+                    )}
+                  </code>
+                </pre>
+              </div>
+            </div>
+
+            {backgroundDetailExample ? (
+              <div className="response-variant">
+                <div className="response-variant__heading">
+                  <span>Detail response: {backgroundDetailExample.name}</span>
+                  <code>GET /api/backgrounds/{backgroundDetailExample.slug}</code>
+                </div>
+                <div className="response-field-list">
+                  {backgroundDetailResponseFields.map((field) => (
+                    <article className="response-field-card" key={field.name}>
+                      <span>{field.name}</span>
+                      <p>{field.description}</p>
+                      <strong>{field.type}</strong>
+                    </article>
+                  ))}
+                </div>
+                <div className="response-example">
+                  <div className="response-example__header">
+                    <span>Example JSON</span>
+                    <code>200 OK</code>
+                  </div>
+                  <pre>
+                    <code>{JSON.stringify(backgroundDetailExample, null, 2)}</code>
+                  </pre>
+                </div>
+              </div>
+            ) : null}
+          </section>
+
+          <button className="guide-accordion__close" onClick={onClose} type="button">
+            Close Backgrounds chapter
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1908,6 +1908,145 @@ li {
   line-height: 1.5;
 }
 
+.background-guide-card__details {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 22px 24px;
+  text-align: center;
+}
+
+.background-guide-card__details p {
+  margin: 0;
+  color: #5a2a1a;
+  font-family: var(--font-heading), sans-serif;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.background-guide-card__details ul {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.background-guide-card__details li {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 18px 0;
+  border-top: 1px solid rgba(90, 42, 26, 0.2);
+  text-align: center;
+}
+
+.background-guide-card__details li:first-child {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.background-guide-card__details strong {
+  display: block;
+  color: #3d190f;
+  font-family: var(--font-heading), sans-serif;
+  font-size: 1.08rem;
+}
+
+.background-guide-card__details span {
+  display: block;
+  max-width: 72ch;
+  color: #4b2c1d;
+  font-family: var(--font-body), sans-serif;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.background-guide-card__details .attribute-skill-list {
+  justify-content: center;
+}
+
+.background-guide-card__option-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  width: 100%;
+  gap: 12px;
+  overflow: hidden;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 221, 176, 0.14);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(164, 104, 67, 0.18),
+      transparent 40%
+    ),
+    linear-gradient(180deg, rgba(45, 20, 12, 0.98), rgba(90, 42, 26, 0.98));
+  box-shadow: inset 0 1px 0 rgba(255, 238, 211, 0.08);
+}
+
+.background-guide-card__option-card {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+  min-height: 100%;
+  padding: 18px 20px;
+  text-align: center;
+}
+
+.background-guide-card__option-card:not(:first-child) {
+  border-left: 1px solid rgba(255, 228, 189, 0.1);
+}
+
+.background-guide-card__option-card p {
+  margin: 0;
+  color: #ffd3a0;
+  font-family: var(--font-heading), sans-serif;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.background-guide-card__option-card ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 0;
+  list-style-position: inside;
+  color: #f7e6c8;
+  font-family: var(--font-body), sans-serif;
+  line-height: 1.5;
+  text-align: center;
+}
+
+.background-guide-card__option-card li {
+  display: list-item;
+  padding: 0;
+  border: 0;
+  text-align: center;
+}
+
+@media (max-width: 760px) {
+  .background-guide-card__option-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .background-guide-card__option-card {
+    padding: 18px 20px;
+  }
+
+  .background-guide-card__option-card:not(:first-child) {
+    border-left: 0;
+    border-top: 1px solid rgba(255, 228, 189, 0.1);
+  }
+}
+
 .species-subspecies {
   overflow: hidden;
   border-top: 3px solid rgba(61, 25, 15, 0.88);

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -2,6 +2,7 @@ import { GuidesAccordion } from '@/app/components/guides-accordion';
 import { getSql } from '@/app/lib/db';
 import { formatSpeciesDetail } from '@/app/lib/species';
 import type { Attribute } from '@/app/types/attribute';
+import type { BackgroundDetail } from '@/app/types/background';
 import type { ClassDetail } from '@/app/types/class';
 import type { SkillDetail } from '@/app/types/skill';
 import type { SpeciesDetail } from '@/app/types/species';
@@ -134,18 +135,50 @@ async function getSpecies(): Promise<SpeciesDetail[]> {
   ) as SpeciesDetail[];
 }
 
+async function getBackgrounds(): Promise<BackgroundDetail[]> {
+  const sql = getSql();
+  const backgroundRows = await sql`
+    SELECT
+      id,
+      name,
+      slug,
+      description,
+      abilityscores,
+      feat,
+      skillproficiencies,
+      toolproficiency,
+      equipmentoptions
+    FROM backgrounds
+    ORDER BY name
+  `;
+
+  return backgroundRows.map((background) => ({
+    id: background.id,
+    name: background.name,
+    slug: background.slug,
+    description: background.description,
+    abilityScores: background.abilityscores,
+    feat: background.feat,
+    skillProficiencies: background.skillproficiencies,
+    toolProficiency: background.toolproficiency,
+    equipmentOptions: background.equipmentoptions,
+  })) as BackgroundDetail[];
+}
+
 export default async function GuidesPage() {
-  const [attributes, skills, classes, species] = await Promise.all([
+  const [attributes, skills, classes, species, backgrounds] = await Promise.all([
     getAttributes(),
     getSkills(),
     getClasses(),
     getSpecies(),
+    getBackgrounds(),
   ]);
 
   return (
     <main className="page-frame">
       <GuidesAccordion
         attributes={attributes}
+        backgrounds={backgrounds}
         classes={classes}
         skills={skills}
         species={species}


### PR DESCRIPTION
## Summary

This PR starts the `/guides` chapter for `Backgrounds` and brings it in line with the educational pattern already used by other guide chapters.

The new chapter is now available from the guides menu and includes:
- chapter index
- single-card navigation
- previous / index / next controls
- introductory educational content for the list and detail endpoints
- initial visual support for background-specific artwork
- cross-navigation from background ability scores to `Attributes`
- cross-navigation from background skill proficiencies to `Skills`

The implementation keeps `/docs` as the OpenAPI-oriented reference and `/guides` as the more educational, player-facing layer.

## What Changed

- enabled the `Backgrounds` chapter in the `/guides` menu
- loaded background data into the guides page
- added a first functional `Backgrounds` chapter with:
  - one background card shown at a time
  - active item selection from chapter index
  - smooth chapter/card navigation
  - educational “How to use” section
  - “Expected return” section for list and detail responses
- added artwork support for the currently mapped backgrounds
- updated the background card layout to better match the existing visual language
- moved `Tool proficiency` and `Feat` into the `What this background grants` section
- improved `Equipment options` presentation with clearer option grouping
- refactored the new background guide code into smaller files for easier maintenance

## Refactor

To keep `guides-accordion.tsx` manageable, the new background-related logic was split into dedicated files:

- `app/components/guides/backgrounds-guide-chapter.tsx`
- `app/components/guides/background-images.ts`
- `app/components/guides/background-response-fields.ts`
- `app/components/guides/background-guide-utils.ts`

This keeps the main accordion component focused on orchestration while making background assets and behavior easier to evolve.

## Validation

- `npm exec -- eslint app --ext .ts,.tsx`
- `npm exec -- tsc --noEmit`
