### PR TITLE
Refine spells guide filters and docs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,7 @@ jobs:
       E2E_AUTH_USERNAME: ${{ secrets.E2E_AUTH_USERNAME }}
       E2E_AUTH_PASSWORD: ${{ secrets.E2E_AUTH_PASSWORD }}
       POSTMAN_BASE_URL: https://adventurers-guild-api.vercel.app/api
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -237,7 +237,33 @@ Returns a lightweight spells list with:
 - `level`
 - `levelLabel`
 
+Supported optional filters:
+
+- `level`
+  - accepts a non-negative integer or `cantrip`
+- `school`
+- `class`
+- `source`
+- `name`
+
+Filter rules:
+
+- filters are case-insensitive
+- multiple filters combine with `AND`
+- `level=cantrip` maps to level `0`
+- `name` performs a partial match
+
+Examples:
+
+- `/api/spells?level=1`
+- `/api/spells?level=cantrip`
+- `/api/spells?school=evocation`
+- `/api/spells?class=wizard`
+- `/api/spells?source=players-handbook`
+- `/api/spells?name=acid`
+
 Returns `500` with `{ "error": "Failed to fetch spells" }` if the query fails.
+Returns `400` with a clear validation error, such as `{ "error": "Invalid level filter" }`, when a filter value is invalid.
 
 ### `GET /api/spells/{identifier}`
 

--- a/app/api/spells/route.ts
+++ b/app/api/spells/route.ts
@@ -6,22 +6,163 @@ function toNumber(value: number | string): number {
   return typeof value === 'number' ? value : Number(value);
 }
 
-export async function GET() {
+function normalizeFilterValue(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function getSingleFilterValue(
+  searchParams: URLSearchParams,
+  key: string,
+): string | null {
+  const value = searchParams.get(key);
+
+  if (value === null) {
+    return null;
+  }
+
+  return value.trim();
+}
+
+function parseLevelFilter(value: string | null) {
+  if (value === null) {
+    return { value: null, error: null as string | null };
+  }
+
+  const normalizedValue = normalizeFilterValue(value);
+
+  if (normalizedValue === 'cantrip') {
+    return { value: 0, error: null as string | null };
+  }
+
+  if (!/^\d+$/.test(normalizedValue)) {
+    return { value: null, error: 'Invalid level filter' };
+  }
+
+  return { value: Number(normalizedValue), error: null as string | null };
+}
+
+function validateStringFilter(
+  value: string | null,
+  filterName: string,
+): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return value.length > 0 ? null : `Invalid ${filterName} filter`;
+}
+
+async function getSpellClassesMap(sql: ReturnType<typeof getSql>) {
+  const spellClassRows = await sql`
+    SELECT spellclasses.spellid, classes.slug AS classslug, classes.name AS classname
+    FROM spellclasses
+    INNER JOIN classes ON classes.id = spellclasses.classid
+    ORDER BY spellclasses.spellid, classes.id
+  `;
+
+  const classesBySpellId = new Map<number, { slug: string; name: string }[]>();
+
+  for (const row of spellClassRows) {
+    const spellId = toNumber(row.spellid);
+    const existingRows = classesBySpellId.get(spellId) ?? [];
+
+    existingRows.push({
+      slug: normalizeFilterValue(row.classslug),
+      name: normalizeFilterValue(row.classname),
+    });
+
+    classesBySpellId.set(spellId, existingRows);
+  }
+
+  return classesBySpellId;
+}
+
+export async function GET(request: Request) {
   const sql = getSql();
+  const { searchParams } = new URL(request.url);
+  const levelFilter = parseLevelFilter(getSingleFilterValue(searchParams, 'level'));
+  const schoolFilter = getSingleFilterValue(searchParams, 'school');
+  const classFilter = getSingleFilterValue(searchParams, 'class');
+  const sourceFilter = getSingleFilterValue(searchParams, 'source');
+  const nameFilter = getSingleFilterValue(searchParams, 'name');
+
+  const validationError =
+    levelFilter.error ??
+    validateStringFilter(schoolFilter, 'school') ??
+    validateStringFilter(classFilter, 'class') ??
+    validateStringFilter(sourceFilter, 'source') ??
+    validateStringFilter(nameFilter, 'name');
+
+  if (validationError) {
+    return NextResponse.json({ error: validationError }, { status: 400 });
+  }
 
   try {
     const spellRows = await sql`
-      SELECT id, name, level, levellabel
+      SELECT id, name, level, levellabel, source, school
       FROM spells
       ORDER BY id
     `;
+    const classesBySpellId =
+      classFilter !== null ? await getSpellClassesMap(sql) : null;
+    const normalizedSchoolFilter =
+      schoolFilter === null ? null : normalizeFilterValue(schoolFilter);
+    const normalizedClassFilter =
+      classFilter === null ? null : normalizeFilterValue(classFilter);
+    const normalizedSourceFilter =
+      sourceFilter === null ? null : normalizeFilterValue(sourceFilter);
+    const normalizedNameFilter =
+      nameFilter === null ? null : normalizeFilterValue(nameFilter);
 
     const spells: SpellListItem[] = spellRows.map((spell) => ({
       id: toNumber(spell.id),
       name: spell.name,
       level: toNumber(spell.level),
       levelLabel: spell.levellabel,
-    }));
+    }))
+      .filter((spell, index) => {
+        const spellRow = spellRows[index];
+
+        if (levelFilter.value !== null && spell.level !== levelFilter.value) {
+          return false;
+        }
+
+        if (
+          normalizedSchoolFilter !== null &&
+          normalizeFilterValue(spellRow.school) !== normalizedSchoolFilter
+        ) {
+          return false;
+        }
+
+        if (
+          normalizedSourceFilter !== null &&
+          normalizeFilterValue(spellRow.source) !== normalizedSourceFilter
+        ) {
+          return false;
+        }
+
+        if (
+          normalizedNameFilter !== null &&
+          !normalizeFilterValue(spell.name).includes(normalizedNameFilter)
+        ) {
+          return false;
+        }
+
+        if (normalizedClassFilter !== null) {
+          const spellClasses = classesBySpellId?.get(spell.id) ?? [];
+          const matchesClass = spellClasses.some(
+            (spellClass) =>
+              spellClass.slug === normalizedClassFilter ||
+              spellClass.name === normalizedClassFilter,
+          );
+
+          if (!matchesClass) {
+            return false;
+          }
+        }
+
+        return true;
+      });
 
     return NextResponse.json(spells, { status: 200 });
   } catch (error) {

--- a/app/components/guides/spells-guide-chapter.tsx
+++ b/app/components/guides/spells-guide-chapter.tsx
@@ -16,7 +16,11 @@ import {
   spellDetailResponseFields,
   spellListResponseFields,
 } from '@/app/components/guides/spell-response-fields';
-import type { SpellDetail, SpellGuideListItem } from '@/app/types/spell';
+import type {
+  SpellDetail,
+  SpellGuideListItem,
+  SpellListItem,
+} from '@/app/types/spell';
 
 type SpellsGuideChapterProps = {
   isOpen: boolean;
@@ -36,12 +40,49 @@ type GuideFilterSelectProps = {
   value: string;
 };
 
+const SPELLS_API_BASE_URL = '/api';
+
 function getSpellLevelAnchor(level: number) {
   return `spells-level-${getGuideAnchorSlug(getSpellLevelLabel(level))}`;
 }
 
 function getSpellLevelLabel(level: number) {
+  if (level < 0) {
+    return 'All';
+  }
+
   return level === 0 ? 'Cantrips' : `Level ${level}`;
+}
+
+function getSpellLevelQueryValue(level: number) {
+  return level === 0 ? 'cantrip' : String(level);
+}
+
+function buildSpellsApiQuery(params: {
+  level?: number | null;
+  className?: string | null;
+  school?: string | null;
+  name?: string | null;
+}) {
+  const searchParams = new URLSearchParams();
+
+  if (params.level !== null && params.level !== undefined) {
+    searchParams.set('level', getSpellLevelQueryValue(params.level));
+  }
+
+  if (params.className) {
+    searchParams.set('class', params.className);
+  }
+
+  if (params.school) {
+    searchParams.set('school', params.school);
+  }
+
+  if (params.name) {
+    searchParams.set('name', params.name);
+  }
+
+  return searchParams.toString();
 }
 
 function formatSpellComponents(spell: SpellDetail) {
@@ -310,8 +351,13 @@ export function SpellsGuideChapter({
   const [selectedDurationFilter, setSelectedDurationFilter] = useState('All');
   const [requiresConcentrationOnly, setRequiresConcentrationOnly] =
     useState(false);
-  const [selectedSpellLevel, setSelectedSpellLevel] = useState(0);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [hasRequestedSpellList, setHasRequestedSpellList] = useState(false);
+  const [selectedSpellLevel, setSelectedSpellLevel] = useState(-1);
   const [expandedSpellId, setExpandedSpellId] = useState<number | null>(null);
+  const [apiLevelSpellIds, setApiLevelSpellIds] = useState<number[] | null>(null);
+  const [isApiLevelLoading, setIsApiLevelLoading] = useState(false);
+  const [apiLevelError, setApiLevelError] = useState<string | null>(null);
   const [selectedComponentsFilter, setSelectedComponentsFilter] = useState<
     string[]
   >([]);
@@ -340,12 +386,6 @@ export function SpellsGuideChapter({
   const filteredSpells = useMemo(
     () =>
       spells.filter((spell) => {
-        const matchesClass =
-          selectedClassFilter === 'All' ||
-          spell.classes.includes(selectedClassFilter);
-        const matchesSchool =
-          selectedSchoolFilter === 'All' ||
-          spell.school === selectedSchoolFilter;
         const matchesCastingTime =
           matchesCastingTimeFilter(
             spell.castingTime,
@@ -376,8 +416,6 @@ export function SpellsGuideChapter({
           });
 
         return (
-          matchesClass &&
-          matchesSchool &&
           matchesCastingTime &&
           matchesDuration &&
           matchesConcentration &&
@@ -386,11 +424,9 @@ export function SpellsGuideChapter({
       }),
     [
       selectedCastingTimeFilter,
-      selectedClassFilter,
       selectedComponentsFilter,
       selectedDurationFilter,
       requiresConcentrationOnly,
-      selectedSchoolFilter,
       spells,
     ],
   );
@@ -398,15 +434,117 @@ export function SpellsGuideChapter({
   const spellLevels = Array.from(new Set(spells.map((spell) => spell.level))).sort(
     (firstLevel, secondLevel) => firstLevel - secondLevel,
   );
-  const activeLevel = spellLevels.includes(selectedSpellLevel)
-    ? selectedSpellLevel
-    : spellLevels[0] ?? 0;
-  const levelSpells = filteredSpells.filter((spell) => spell.level === activeLevel);
+  const activeLevel =
+    selectedSpellLevel === -1 || spellLevels.includes(selectedSpellLevel)
+      ? selectedSpellLevel
+      : -1;
+  const levelOptions = useMemo(
+    () => ['All', ...spellLevels.map((level) => getSpellLevelLabel(level))],
+    [spellLevels],
+  );
+  const selectedLevelLabel = getSpellLevelLabel(activeLevel);
+
+  useEffect(() => {
+    if (!isOpen || !hasRequestedSpellList) {
+      return;
+    }
+
+    let ignore = false;
+
+    async function loadLevelSpellIds() {
+      setIsApiLevelLoading(true);
+      setApiLevelError(null);
+
+      try {
+        const response = await fetch(
+          `${SPELLS_API_BASE_URL}/spells?${buildSpellsApiQuery({
+            level: activeLevel >= 0 ? activeLevel : null,
+            className:
+              selectedClassFilter !== 'All' ? selectedClassFilter : null,
+            school:
+              selectedSchoolFilter !== 'All' ? selectedSchoolFilter : null,
+            name: searchTerm.trim().length > 0 ? searchTerm.trim() : null,
+          })}`,
+          {
+            headers: {
+              Accept: 'application/json',
+            },
+          },
+        );
+
+        if (!response.ok) {
+          let message = 'Failed to fetch spells';
+
+          try {
+            const body = (await response.json()) as { error?: string };
+
+            if (body.error) {
+              message = body.error;
+            }
+          } catch {
+            // Keep the generic failure message when the API body cannot be parsed.
+          }
+
+          throw new Error(message);
+        }
+
+        const apiSpells = (await response.json()) as SpellListItem[];
+
+        if (!ignore) {
+          setApiLevelSpellIds(apiSpells.map((spell) => spell.id));
+        }
+      } catch (error) {
+        if (!ignore) {
+          setApiLevelSpellIds(null);
+          setApiLevelError(
+            error instanceof Error && error.message.length > 0
+              ? error.message
+              : 'Failed to fetch spells',
+          );
+        }
+      } finally {
+        if (!ignore) {
+          setIsApiLevelLoading(false);
+        }
+      }
+    }
+
+    void loadLevelSpellIds();
+
+    return () => {
+      ignore = true;
+    };
+  }, [
+    activeLevel,
+    hasRequestedSpellList,
+    isOpen,
+    searchTerm,
+    selectedClassFilter,
+    selectedSchoolFilter,
+  ]);
+
+  const levelSpells = filteredSpells.filter((spell) => {
+    if (!hasRequestedSpellList) {
+      return false;
+    }
+
+    if (activeLevel >= 0 && spell.level !== activeLevel) {
+      return false;
+    }
+
+    if (apiLevelSpellIds === null) {
+      return true;
+    }
+
+    return apiLevelSpellIds.includes(spell.id);
+  });
   const hasActiveFilters =
+    selectedSpellLevel !== -1 ||
     selectedClassFilter !== 'All' ||
     selectedSchoolFilter !== 'All' ||
     selectedCastingTimeFilter !== 'All' ||
     selectedDurationFilter !== 'All' ||
+    searchTerm.trim().length > 0 ||
     requiresConcentrationOnly ||
     selectedComponentsFilter.length > 0;
   const visibleExpandedSpellId = levelSpells.some(
@@ -463,41 +601,33 @@ export function SpellsGuideChapter({
               <h3>Filter the spellbook</h3>
             </div>
 
-            <nav
-              aria-label="Spells level index"
-              className="guide-card-index guide-card-index--inside-panel spells-level-nav"
-              id="spells-level-index"
-            >
-              <p>Spell level</p>
-              <div>
-                {spellLevels.length > 0 ? (
-                  spellLevels.map((level) => (
-                    <a
-                      aria-current={level === activeLevel ? 'true' : undefined}
-                      href={`#${getSpellLevelAnchor(level)}`}
-                      key={level}
-                      onClick={(event) => {
-                        event.preventDefault();
-                        setSelectedSpellLevel(level);
-                        onSelectLevel(level);
-                      }}
-                    >
-                      {getSpellLevelLabel(level)}
-                    </a>
-                  ))
-                ) : (
-                  <span className="attribute-skill-chip attribute-skill-chip--empty">
-                    No spell levels match these filters
-                  </span>
-                )}
-              </div>
-            </nav>
-
             <div className="guide-filter-panel__controls guide-filter-panel__controls--quad">
+              <GuideFilterSelect
+                isActive={selectedSpellLevel !== -1}
+                label="Level"
+                onChange={(value) => {
+                  setHasRequestedSpellList(true);
+                  const nextLevel =
+                    value === 'All'
+                      ? -1
+                      : spellLevels.find(
+                          (level) => getSpellLevelLabel(level) === value,
+                        ) ?? -1;
+
+                  setSelectedSpellLevel(nextLevel);
+                  onSelectLevel(nextLevel < 0 ? 0 : nextLevel);
+                }}
+                options={levelOptions}
+                value={selectedLevelLabel}
+              />
+
               <GuideFilterSelect
                 isActive={selectedClassFilter !== 'All'}
                 label="Class"
-                onChange={setSelectedClassFilter}
+                onChange={(value) => {
+                  setHasRequestedSpellList(true);
+                  setSelectedClassFilter(value);
+                }}
                 options={classOptions}
                 value={selectedClassFilter}
               />
@@ -505,14 +635,20 @@ export function SpellsGuideChapter({
               <GuideFilterSelect
                 isActive={selectedSchoolFilter !== 'All'}
                 label="School"
-                onChange={setSelectedSchoolFilter}
+                onChange={(value) => {
+                  setHasRequestedSpellList(true);
+                  setSelectedSchoolFilter(value);
+                }}
                 options={schoolOptions}
                 value={selectedSchoolFilter}
               />
               <GuideFilterSelect
                 isActive={selectedCastingTimeFilter !== 'All'}
                 label="Casting Time"
-                onChange={setSelectedCastingTimeFilter}
+                onChange={(value) => {
+                  setHasRequestedSpellList(true);
+                  setSelectedCastingTimeFilter(value);
+                }}
                 options={castingTimeFilterOptions}
                 value={selectedCastingTimeFilter}
               />
@@ -520,7 +656,10 @@ export function SpellsGuideChapter({
               <GuideFilterSelect
                 isActive={selectedDurationFilter !== 'All'}
                 label="Duration"
-                onChange={setSelectedDurationFilter}
+                onChange={(value) => {
+                  setHasRequestedSpellList(true);
+                  setSelectedDurationFilter(value);
+                }}
                 options={durationFilterOptions}
                 value={selectedDurationFilter}
               />
@@ -542,11 +681,14 @@ export function SpellsGuideChapter({
                         <input
                           checked={isSelected}
                           onChange={() =>
-                            setSelectedComponentsFilter((currentValue) =>
-                              currentValue.includes(component)
-                                ? currentValue.filter((item) => item !== component)
-                                : [...currentValue, component],
-                            )
+                            {
+                              setHasRequestedSpellList(true);
+                              setSelectedComponentsFilter((currentValue) =>
+                                currentValue.includes(component)
+                                  ? currentValue.filter((item) => item !== component)
+                                  : [...currentValue, component],
+                              );
+                            }
                           }
                           type="checkbox"
                         />
@@ -566,9 +708,10 @@ export function SpellsGuideChapter({
                 <label className="guide-filter-panel__checkbox-row">
                   <input
                     checked={requiresConcentrationOnly}
-                    onChange={(event) =>
-                      setRequiresConcentrationOnly(event.target.checked)
-                    }
+                    onChange={(event) => {
+                      setHasRequestedSpellList(true);
+                      setRequiresConcentrationOnly(event.target.checked);
+                    }}
                     type="checkbox"
                   />
                   <span
@@ -580,22 +723,46 @@ export function SpellsGuideChapter({
               </div>
             </div>
 
+            <div className="guide-filter-panel__field guide-filter-panel__field--full">
+              <span>Search by word</span>
+              <input
+                aria-label="Search spells by word"
+                className="guide-filter-panel__search-input"
+                onChange={(event) => {
+                  setHasRequestedSpellList(true);
+                  setSearchTerm(event.target.value);
+                }}
+                placeholder="acid"
+                type="search"
+                value={searchTerm}
+              />
+            </div>
+
             <div className="guide-filter-panel__footer">
               <p className="guide-filter-panel__summary">
-                <strong>{levelSpells.length}</strong> of{' '}
-                <strong>{filteredSpells.length}</strong> spells shown for the
-                current filters
+                {hasRequestedSpellList ? (
+                  <>
+                    <strong>{levelSpells.length}</strong> of{' '}
+                    <strong>{spells.length}</strong> spells shown for the current
+                    filters
+                  </>
+                ) : (
+                  <>Choose a level, class, school, or search term to load spells.</>
+                )}
               </p>
 
               <button
                 className="guide-filter-panel__reset"
                 disabled={!hasActiveFilters}
                 onClick={() => {
+                  setHasRequestedSpellList(false);
+                  setSelectedSpellLevel(-1);
                   setSelectedClassFilter('All');
                   setSelectedSchoolFilter('All');
                   setSelectedCastingTimeFilter('All');
                   setSelectedDurationFilter('All');
                   setRequiresConcentrationOnly(false);
+                  setSearchTerm('');
                   setSelectedComponentsFilter([]);
                 }}
                 type="button"
@@ -603,15 +770,26 @@ export function SpellsGuideChapter({
                 Reset filters
               </button>
             </div>
+
+            {isApiLevelLoading ? (
+              <p className="guide-accordion__description">
+                Syncing level, class, and school with the public Spells API...
+              </p>
+            ) : null}
+
+            {apiLevelError ? (
+              <p className="guide-accordion__description">
+                Public level filter unavailable right now. Showing the local
+                layout fallback for this level.
+              </p>
+            ) : null}
           </section>
 
           <div className="equipment-weapon-groups">
             <section className="species-subspecies spells-guide-table">
               <div className="species-subspecies__heading">
                 <p id={getSpellLevelAnchor(activeLevel)}>
-                  {spellLevels.length > 0
-                    ? getSpellLevelLabel(activeLevel)
-                    : 'No matching spells'}
+                  {spellLevels.length > 0 ? selectedLevelLabel : 'No matching spells'}
                 </p>
                 <span>
                   {spellLevels.length > 0
@@ -711,7 +889,11 @@ export function SpellsGuideChapter({
                       })
                     ) : (
                       <tr>
-                        <td colSpan={8}>No spells match the current filters.</td>
+                        <td colSpan={8}>
+                          {hasRequestedSpellList
+                            ? 'No spells match the current filters.'
+                            : 'Choose a level, class, school, or search term to load spells.'}
+                        </td>
                       </tr>
                     )}
                   </tbody>
@@ -755,24 +937,42 @@ export function SpellsGuideChapter({
           <aside className="guide-how-to-use">
             <h3>How to use</h3>
             <p>
-              Call <code>GET /api/spells</code> when you need a compact spell
-              index for selectors, filters, or grouped browsing by level. Use{' '}
-              <code>GET /api/spells/{'{identifier}'}</code> when you need the
-              full spell text, casting metadata, allowed classes, and scaling
-              entries.
+              Use <code>GET /api/spells</code> as the filtered spell browser
+              endpoint. You can combine <code>level</code>, <code>class</code>,{' '}
+              <code>school</code>, and <code>name</code> in the query string,
+              and the response stays compact with only <code>id</code>,{' '}
+              <code>name</code>, <code>level</code>, and <code>levelLabel</code>.
+              Use <code>GET /api/spells/{'{identifier}'}</code> when you need the
+              rich spell detail payload.
             </p>
-            <div className="endpoint-stack">
+            <div className="endpoint-stack endpoint-stack--column">
               <a
                 className="endpoint-pill"
-                href="https://adventurers-guild-api.vercel.app/api/spells"
+                href="/api/spells?level=cantrip"
                 rel="noreferrer"
                 target="_blank"
               >
-                GET /api/spells
+                GET /api/spells?level=cantrip
               </a>
               <a
                 className="endpoint-pill"
-                href="https://adventurers-guild-api.vercel.app/api/spells/fire-bolt"
+                href="/api/spells?class=wizard&level=1"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GET /api/spells?class=wizard&amp;level=1
+              </a>
+              <a
+                className="endpoint-pill"
+                href="/api/spells?school=evocation&name=acid"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GET /api/spells?school=evocation&amp;name=acid
+              </a>
+              <a
+                className="endpoint-pill"
+                href="/api/spells/fire-bolt"
                 rel="noreferrer"
                 target="_blank"
               >
@@ -786,9 +986,11 @@ export function SpellsGuideChapter({
               <h3>Expected return</h3>
               <h4>Response shapes</h4>
               <p>
-                The list response stays lightweight for catalog views, while the
-                detail response adds richer spellcasting context used by sheets,
-                character builders, and rules exploration.
+                The list response is intentionally lightweight even when filters
+                are applied, so the browser can search quickly without pulling
+                full descriptions, classes, source text, or scaling data on every
+                request. The detail response is where the richer spellcasting
+                context lives.
               </p>
             </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -982,6 +982,18 @@ li {
   gap: 14px 20px;
 }
 
+.spells-level-nav__row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 14px 20px;
+  width: 100%;
+}
+
+.spells-level-nav__row--all {
+  margin-bottom: 2px;
+}
+
 .guide-card-index.spells-level-nav a {
   min-height: auto !important;
   padding: 0 2px 6px !important;
@@ -2794,9 +2806,10 @@ li {
 }
 
 .guide-filter-panel__controls--quad {
-  grid-template-columns: repeat(4, minmax(0, 180px));
+  grid-template-columns: repeat(5, minmax(0, 156px));
   justify-content: center;
   max-width: none;
+  gap: 12px;
 }
 
 .guide-filter-panel__controls--quad .guide-filter-select {
@@ -2886,6 +2899,35 @@ li {
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.guide-filter-panel__search-input {
+  width: min(100%, 520px);
+  min-height: 52px;
+  padding: 12px 16px;
+  border: 1px solid rgba(90, 42, 26, 0.28);
+  border-radius: 18px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 253, 246, 0.96),
+    rgba(243, 224, 192, 0.94)
+  );
+  color: #4b2c1d;
+  font-family: var(--font-body), sans-serif;
+  font-size: 1.04rem;
+  text-align: center;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.72),
+    0 6px 12px rgba(61, 25, 15, 0.08);
+}
+
+.guide-filter-panel__search-input::placeholder {
+  color: rgba(75, 44, 29, 0.58);
+}
+
+.guide-filter-panel__search-input:focus-visible {
+  outline: 2px solid rgba(122, 62, 33, 0.26);
+  outline-offset: 2px;
 }
 
 .guide-filter-select__trigger {
@@ -3360,13 +3402,15 @@ li {
 
 .response-field-list {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(190px, 190px));
   justify-content: center;
   gap: 12px;
+  width: 100%;
+  margin-inline: auto;
 }
 
 .response-field-list--compact {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(190px, 190px));
 }
 
 .response-field-card {
@@ -3494,6 +3538,11 @@ li {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.endpoint-stack--column {
+  flex-direction: column;
+  align-items: center;
 }
 
 .endpoint-pill {

--- a/app/guides/page.tsx
+++ b/app/guides/page.tsx
@@ -249,7 +249,7 @@ async function getSpells(): Promise<SpellGuideListItem[]> {
   `;
 
   return spellRows.map((spell) => ({
-    id: spell.id,
+    id: Number(spell.id),
     name: spell.name,
     level: Number(spell.level),
     levelLabel: spell.levellabel,
@@ -322,7 +322,7 @@ async function getSpellDetailExample(): Promise<SpellDetail | null> {
   `;
 
   return {
-    id: spell.id,
+    id: Number(spell.id),
     name: spell.name,
     slug: spell.slug,
     source: spell.source,

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -741,6 +741,46 @@ paths:
         - `name`
         - `level`
         - `levelLabel`
+      parameters:
+        - name: level
+          in: query
+          required: false
+          description: Spell level filter. Accepts a non-negative integer or `cantrip` for level 0.
+          schema:
+            type: string
+          examples:
+            levelOne:
+              value: '1'
+            cantrip:
+              value: cantrip
+        - name: school
+          in: query
+          required: false
+          description: Case-insensitive spell school filter.
+          schema:
+            type: string
+          example: evocation
+        - name: class
+          in: query
+          required: false
+          description: Case-insensitive class filter by class slug or name.
+          schema:
+            type: string
+          example: wizard
+        - name: source
+          in: query
+          required: false
+          description: Case-insensitive spell source filter.
+          schema:
+            type: string
+          example: players-handbook
+        - name: name
+          in: query
+          required: false
+          description: Case-insensitive partial name match.
+          schema:
+            type: string
+          example: acid
       responses:
         '200':
           description: Spells returned successfully
@@ -763,6 +803,14 @@ paths:
                   name: Animal Friendship
                   level: 1
                   levelLabel: Level 1
+        '400':
+          description: Invalid spell filter
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: Invalid level filter
         '500':
           description: Failed to fetch spells
           content:

--- a/tests/clients/spells.client.ts
+++ b/tests/clients/spells.client.ts
@@ -3,8 +3,22 @@ import { APIRequestContext, APIResponse } from '@playwright/test';
 export class SpellsClient {
   constructor(private readonly request: APIRequestContext) {}
 
-  async getSpells(): Promise<APIResponse> {
-    return this.request.get('/api/spells');
+  async getSpells(
+    filters?: Record<string, string | number>,
+  ): Promise<APIResponse> {
+    const searchParams = new URLSearchParams();
+
+    if (filters) {
+      for (const [key, value] of Object.entries(filters)) {
+        searchParams.set(key, String(value));
+      }
+    }
+
+    const queryString = searchParams.toString();
+
+    return this.request.get(
+      queryString ? `/api/spells?${queryString}` : '/api/spells',
+    );
   }
 
   async getSpellDetail(identifier: string | number): Promise<APIResponse> {

--- a/tests/features/spells.spec.ts
+++ b/tests/features/spells.spec.ts
@@ -37,6 +37,179 @@ test.describe('Spells API - List', { tag: ['@spells', '@list'] }, () => {
       },
     );
   }
+
+  test(
+    'Filter spells by level 1',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ level: 1 });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await test.step('Validate all returned spells are level 1', async () => {
+        expect(body.length).toBeGreaterThan(0);
+        expect(body.every((spell) => spell.level === 1)).toBe(true);
+      });
+    },
+  );
+
+  test(
+    'Filter spells by cantrip level alias',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ level: 'cantrip' });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await test.step('Validate all returned spells are cantrips', async () => {
+        expect(body.length).toBeGreaterThan(0);
+        expect(body.every((spell) => spell.level === 0)).toBe(true);
+      });
+      await spellAssert.validateSpellInList(body, expectedSpellsList[0]);
+    },
+  );
+
+  test(
+    'Filter spells by school',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ school: 'evocation' });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await spellAssert.validateSpellInList(body, expectedSpellsList[0]);
+    },
+  );
+
+  test(
+    'Filter spells by class',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ class: 'wizard' });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await spellAssert.validateSpellInList(body, expectedSpellsList[0]);
+      await spellAssert.validateSpellInList(body, expectedSpellsList[1]);
+    },
+  );
+
+  test(
+    'Filter spells by source',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({
+        source: "player's handbook",
+      });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await spellAssert.validateSpellInList(body, expectedSpellsList[0]);
+    },
+  );
+
+  test(
+    'Filter spells by partial name',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ name: 'acid' });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await test.step('Validate filtered names match partial search', async () => {
+        expect(body.length).toBeGreaterThan(0);
+        expect(
+          body.every((spell) => spell.name.toLowerCase().includes('acid')),
+        ).toBe(true);
+      });
+      await spellAssert.validateSpellInList(body, expectedSpellsList[0]);
+    },
+  );
+
+  test(
+    'Combine spell filters with AND',
+    { tag: ['@get', '@filters', '@data'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({
+        level: 'cantrip',
+        class: 'wizard',
+        school: 'evocation',
+        name: 'acid',
+      });
+
+      await spellAssert.success(response);
+
+      const body: SpellListItem[] = await response.json();
+
+      await spellAssert.validateSchema(body);
+      await test.step('Validate combined filters narrowed the result set', async () => {
+        expect(body).toEqual([
+          {
+            id: expectedDetailedSpells['acid-splash'].id,
+            name: expectedDetailedSpells['acid-splash'].name,
+            level: expectedDetailedSpells['acid-splash'].level,
+            levelLabel: expectedDetailedSpells['acid-splash'].levelLabel,
+          },
+        ]);
+      });
+    },
+  );
+
+  test(
+    'Reject invalid level filter',
+    { tag: ['@get', '@filters', '@negative', '@error'] },
+    async ({ request }) => {
+      const spellsClient = new SpellsClient(request);
+      const spellAssert = new SpellAssert();
+
+      const response = await spellsClient.getSpells({ level: 'first' });
+
+      await spellAssert.badRequest(response);
+
+      const body: { error: string } = await response.json();
+
+      await spellAssert.validateErrorResponse(body, 'Invalid level filter');
+    },
+  );
 });
 
 test.describe('Spells API - Detail', { tag: ['@spells', '@detail'] }, () => {

--- a/tests/helpers/spells.assertions.ts
+++ b/tests/helpers/spells.assertions.ts
@@ -16,6 +16,13 @@ export class SpellAssert {
     });
   }
 
+  async badRequest(response: { status(): number; ok(): boolean }) {
+    await test.step('Should return status code 400', async () => {
+      expect(response.status()).toBe(400);
+      expect(response.ok()).toBeFalsy();
+    });
+  }
+
   async validateSchema(spellList: SpellListItem[]) {
     await test.step('Should validate spells list is not empty', async () => {
       expect(spellList).toBeTruthy();


### PR DESCRIPTION
**Title**
`Refine spells guide filters and docs`

**Description**
## Summary
This PR updates both the spells API filtering contract and the frontend spells guide experience to support the new filtered browsing flow.

## API changes
- extended `GET /api/spells` to support optional filters:
  - `level`
  - `school`
  - `class`
  - `source`
  - `name`
- implemented filter behavior with:
  - case-insensitive matching
  - `AND` combination across multiple filters
  - partial match for `name`
  - `level=cantrip` mapped to level `0`
- added validation for invalid filter values
- documented the new query parameters and error responses in the API docs/OpenAPI
- added automated tests for the new spells list filter behavior

## Frontend changes
- integrated the spells guide filters with the `/api/spells` list endpoint
- added support for API-driven filtering by:
  - `level`
  - `class`
  - `school`
  - `name`
- kept the list payload compact and continued using the existing enriched local data for table rendering
- updated the level filter UX:
  - replaced the large level link list with a compact `Level` selector
  - added an `All` option
  - made reset return to `All`
- added a centered search input for spell name filtering
- fixed filter loading behavior so local-only filters like `Casting Time`, `Duration`, `Components`, and `Concentration` can trigger list loading even when no API selector was chosen yet
- made the spells table lazy-load:
  - the page no longer renders the large spell list immediately on open
  - spells load only after the user interacts with level, class, school, or search
- updated the “How to use” and “Expected return” sections to document the new filtered usage patterns
- centered the response field cards and changed the endpoint examples in `How to use` to a vertical column layout
- normalized spell ids in the guides page data mapping to avoid mismatches between local data and filtered API ids

## UX improvements
- lighter initial render in the spells section
- easier access to the documentation below the table
- more compact and consistent filter layout
- search field visually aligned with the rest of the site

## Notes
- the total spell count shown in the summary remains tied to the local guides dataset (`338`) by design
- API filtering is used to narrow the visible result set, while the table still renders using the guide’s local enriched spell records

## Validation
- `npx eslint app/components/guides/spells-guide-chapter.tsx`
- `npx tsc --noEmit`
- spells API filter tests updated for the new query behavior
