### PR TITLE
Validate character ability scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable public API behavior changes are documented in this file.
+
+This project follows Semantic Versioning while the API is pre-1.0:
+
+- `MAJOR` is reserved for a future stable `1.0.0` API contract.
+- `MINOR` versions document meaningful API behavior changes, new endpoints, or stricter validation.
+- `PATCH` versions document fixes that do not intentionally change public behavior.
+
+## [0.2.0] - 2026-04-21
+
+### Changed
+
+- Strengthened `abilityScores` validation across the Characters API.
+- Applied the same `abilityScores` business rules to:
+  - `POST /api/characters`
+  - `PATCH /api/characters/{id}`
+  - `PUT /api/characters/{id}/ability-scores`
+- Invalid `abilityScores` payloads now return more specific `400` error messages while keeping the existing response shape:
+
+```json
+{
+  "error": "..."
+}
+```
+
+### Validation Rules
+
+- `base` and `bonuses` must each contain exactly `STR`, `DEX`, `CON`, `INT`, `WIS`, and `CHA`.
+- All values must be integers.
+- For character levels `1` to `3`, each base score must be between `8` and `15`.
+- Each bonus must be between `0` and `2`.
+- Positive bonuses must target abilities allowed by the character's background.
+- The current background rule requires a `+2/+1` split across different allowed abilities.
+
+### Examples
+
+Base score too high:
+
+```json
+{
+  "error": "Invalid character ability scores payload: base.DEX must be between 8 and 15 for character levels 1 to 3; received 16"
+}
+```
+
+Bonus outside background choices:
+
+```json
+{
+  "error": "Invalid character ability scores payload: bonuses.STR is not allowed by this character's background. Allowed abilities: INT, WIS, CHA"
+}
+```
+
+### Documentation
+
+- Updated README API behavior notes for `POST`, `PATCH`, and `PUT` ability score validation.
+- Updated the Characters guide Attributes card with the relevant request methods and validation examples.
+
+### Tests
+
+- Added regression tests for invalid base scores, invalid bonuses, background choice violations, invalid `+2/+1` splits, incomplete payloads, and invalid `POST`/`PATCH` submissions.
+- Added a flow that verifies invalid updates do not overwrite previously saved valid scores.
+
+## [0.1.0] - Previous
+
+### Added
+
+- Initial documented Adventurers Guild API surface.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Fantasy-themed REST API built with Next.js to support learning and practice around backend testing, API automation, contract validation, and documentation.
 
+## Public API Version
+
+Current public API version: `0.2.0`
+
+Public API behavior changes are documented in [CHANGELOG.md](CHANGELOG.md).
+
+This project uses Semantic Versioning while the API is pre-1.0:
+
+- `MINOR` versions document meaningful API behavior changes, new endpoints, or stricter validation.
+- `PATCH` versions document fixes that do not intentionally change public behavior.
+- `MAJOR` is reserved for a future stable `1.0.0` API contract.
+
 ## Purpose
 
 This project is designed to provide a stable API surface that can be used to practice:

--- a/README.md
+++ b/README.md
@@ -368,6 +368,8 @@ Request body fields:
 - `currency` optional
 - `skillProficiencies` optional
 
+If `abilityScores` is provided, it uses the same validation rules as `PUT /api/characters/{id}/ability-scores`: complete `base` and `bonuses` blocks, integer `STR`, `DEX`, `CON`, `INT`, `WIS`, and `CHA` values, level 1 to 3 base scores between `8` and `15`, bonuses between `0` and `2`, and background-compatible bonus choices.
+
 Response fields:
 
 - `id`
@@ -409,6 +411,7 @@ Returns:
 
 - `201` when the character is created
 - `400` with `{ "error": "Invalid character request payload" }`
+- `400` with a specific ability score validation message, for example `{ "error": "Invalid character ability scores payload: base.STR must be between 8 and 15 for character levels 1 to 3; received 16" }`
 - `401` with `{ "error": "Unauthorized" }`
 - `500` with `{ "error": "Failed to create character" }`
 
@@ -496,10 +499,13 @@ Accepted fields:
 - `currency`
 - `skillProficiencies`
 
+If `abilityScores` is provided, it uses the same validation rules as `PUT /api/characters/{id}/ability-scores`. Sending `abilityScores: null` clears the saved scores.
+
 Returns:
 
 - `200` with the updated character response
 - `400` with `{ "error": "Invalid character request payload" }`
+- `400` with a specific ability score validation message, for example `{ "error": "Invalid character ability scores payload: bonuses.STR is not allowed by this character's background. Allowed abilities: INT, WIS, CHA" }`
 - `401` with `{ "error": "Unauthorized" }`
 - `404` with `{ "error": "Character not found" }`
 - `500` with `{ "error": "Failed to update character" }`
@@ -840,10 +846,19 @@ Request body fields:
 - `abilityScores.base`
 - `abilityScores.bonuses`
 
+Validation rules:
+
+- `base` and `bonuses` must each contain exactly `STR`, `DEX`, `CON`, `INT`, `WIS`, and `CHA`.
+- All values must be integers.
+- For character levels `1` to `3`, each base score must be between `8` and `15`.
+- Each bonus must be between `0` and `2`.
+- Positive bonuses must target abilities allowed by the character's background.
+- The current background rule requires a `+2/+1` split across different allowed abilities.
+
 Returns:
 
 - `200` with the updated ability score selection response
-- `400` with `{ "error": "Invalid character ability scores payload" }`
+- `400` with a specific validation message, for example `{ "error": "Invalid character ability scores payload: base.DEX must be between 8 and 15 for character levels 1 to 3; received 16" }`
 - `400` with `{ "error": "Ability score selection is not available for this character" }`
 - `401` with `{ "error": "Unauthorized" }`
 - `404` with `{ "error": "Character not found" }`

--- a/app/api/characters/[id]/ability-scores/route.ts
+++ b/app/api/characters/[id]/ability-scores/route.ts
@@ -1,7 +1,9 @@
 import { getAuthenticatedOwnerFromRequest } from '@/app/lib/auth';
-import { getCharacterAbilityScoreSelectionContext } from '@/app/lib/character-ability-scores';
 import {
-  isCharacterAbilityScoresInput,
+  getCharacterAbilityScoreSelectionContext,
+  validateCharacterAbilityScoresInput,
+} from '@/app/lib/character-ability-scores';
+import {
   serializeCharacterAbilityScoresInput,
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
@@ -23,8 +25,7 @@ function isCharacterAbilityScoresUpdateRequestBody(
   return (
     typeof value === 'object' &&
     value !== null &&
-    'abilityScores' in value &&
-    isCharacterAbilityScoresInput(value.abilityScores)
+    'abilityScores' in value
   );
 }
 
@@ -70,10 +71,23 @@ export async function PUT(request: Request, { params }: RouteContext) {
       );
     }
 
+    const validationResult = validateCharacterAbilityScoresInput({
+      abilityScores: body.abilityScores,
+      characterLevel: context.characterLevel,
+      selectionRules: context.selectionRules,
+    });
+
+    if (!validationResult.valid) {
+      return NextResponse.json(
+        { error: validationResult.error },
+        { status: 400 },
+      );
+    }
+
     const sql = getSql();
     await sql`
       UPDATE characters
-      SET abilityscores = ${serializeCharacterAbilityScoresInput(body.abilityScores)}, updatedat = NOW()
+      SET abilityscores = ${serializeCharacterAbilityScoresInput(validationResult.abilityScores)}, updatedat = NOW()
       WHERE id = ${parsedId}
         AND ownerid = ${authenticatedOwner.id}
     `;

--- a/app/api/characters/[id]/route.ts
+++ b/app/api/characters/[id]/route.ts
@@ -1,4 +1,8 @@
 import { getAuthenticatedOwnerFromRequest } from '@/app/lib/auth';
+import {
+  getCharacterAbilityScoreRulesByBackgroundId,
+  validateCharacterAbilityScoresInput,
+} from '@/app/lib/character-ability-scores';
 import { clearCharacterEquipmentChoiceRecords } from '@/app/lib/character-equipment-package-choices';
 import {
   formatCharacterResponse,
@@ -132,12 +136,32 @@ export async function PATCH(request: Request, { params }: RouteContext) {
         : existingCharacter.backgroundid;
     const nextLevel =
       body.level !== undefined ? body.level : Number(existingCharacter.level);
-    const nextAbilityScores =
-      body.abilityScores !== undefined
-        ? body.abilityScores === null
-          ? null
-          : serializeCharacterAbilityScoresInput(body.abilityScores)
-        : existingCharacter.abilityscores;
+    let nextAbilityScores = existingCharacter.abilityscores;
+
+    if (body.abilityScores !== undefined) {
+      if (body.abilityScores === null) {
+        nextAbilityScores = null;
+      } else {
+        const selectionRules =
+          await getCharacterAbilityScoreRulesByBackgroundId(nextBackgroundId);
+        const validationResult = validateCharacterAbilityScoresInput({
+          abilityScores: body.abilityScores,
+          characterLevel: nextLevel ?? 1,
+          selectionRules,
+        });
+
+        if (!validationResult.valid) {
+          return NextResponse.json(
+            { error: validationResult.error },
+            { status: 400 },
+          );
+        }
+
+        nextAbilityScores = serializeCharacterAbilityScoresInput(
+          validationResult.abilityScores,
+        );
+      }
+    }
     const nextCurrency =
       body.currency !== undefined
         ? body.currency === null

--- a/app/api/characters/route.ts
+++ b/app/api/characters/route.ts
@@ -1,5 +1,9 @@
 import { getAuthenticatedOwnerFromRequest } from '@/app/lib/auth';
 import {
+  getCharacterAbilityScoreRulesByBackgroundId,
+  validateCharacterAbilityScoresInput,
+} from '@/app/lib/character-ability-scores';
+import {
   formatCharacterResponse,
   getCharacterMissingFields,
   getCharacterStatus,
@@ -13,6 +17,7 @@ import {
 } from '@/app/lib/characters';
 import { getSql } from '@/app/lib/db';
 import {
+  CharacterAbilityScoresInput,
   CharacterCreateRequestBody,
   CharacterListItem,
 } from '@/app/types/character';
@@ -140,10 +145,28 @@ export async function POST(request: Request) {
     const speciesId = body.speciesId ?? null;
     const backgroundId = body.backgroundId ?? null;
     const level = body.level ?? 1;
-    const abilityScores =
-      body.abilityScores === undefined || body.abilityScores === null
-        ? null
-        : serializeCharacterAbilityScoresInput(body.abilityScores);
+    let abilityScores: CharacterAbilityScoresInput | null = null;
+
+    if (body.abilityScores !== undefined && body.abilityScores !== null) {
+      const selectionRules =
+        await getCharacterAbilityScoreRulesByBackgroundId(backgroundId);
+      const validationResult = validateCharacterAbilityScoresInput({
+        abilityScores: body.abilityScores,
+        characterLevel: level,
+        selectionRules,
+      });
+
+      if (!validationResult.valid) {
+        return NextResponse.json(
+          { error: validationResult.error },
+          { status: 400 },
+        );
+      }
+
+      abilityScores = serializeCharacterAbilityScoresInput(
+        validationResult.abilityScores,
+      );
+    }
     const currency =
       body.currency === undefined || body.currency === null
         ? null

--- a/app/components/guides/characters-guide-chapter.tsx
+++ b/app/components/guides/characters-guide-chapter.tsx
@@ -1327,17 +1327,29 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         label: 'Request types',
-        value: 'GET and PUT',
+        value: 'GET, PUT, and PATCH',
+      },
+      {
+        label: 'Path parameter',
+        value: 'Use the character id as {id} in both attribute routes.',
       },
       {
         label: 'Related routes',
         value: 'Use ability-score-options and ability-scores for the full attribute flow.',
       },
+      {
+        label: 'Base score range',
+        value: 'For levels 1 to 3, each base ability score must be between 8 and 15.',
+      },
+      {
+        label: 'Bonus rule',
+        value: 'Bonuses must follow a +2/+1 split across different background-allowed abilities.',
+      },
     ],
     responseHeading: 'Expected return',
     responseSubheading: 'Response contract',
     responseDescription:
-      'Attribute flow is split into helper routes. First read the available ability score rules with GET /api/characters/{id}/ability-score-options, then update the chosen values with PUT /api/characters/{id}/ability-scores.',
+      'Attribute flow is split into helper routes. First read the available ability score rules with GET /api/characters/{id}/ability-score-options, then update the chosen values with PUT /api/characters/{id}/ability-scores. POST /api/characters and PATCH /api/characters/{id} apply the same validation whenever abilityScores is provided.',
     responseFields: [
       {
         name: 'allowedChoices',
@@ -1352,12 +1364,17 @@ const characterTickets: CharacterTicket[] = [
       {
         name: 'abilityScores',
         type: 'object | null',
-        description: 'Resolved ability score block returned after the update.',
+        description: 'Resolved ability score block returned after the update. The request must include complete base and bonuses blocks for STR, DEX, CON, INT, WIS, and CHA.',
       },
       {
         name: 'abilityModifiers',
         type: 'object | null',
         description: 'Derived modifiers calculated from the final ability scores.',
+      },
+      {
+        name: 'error',
+        type: 'string',
+        description: 'Validation failures include the invalid field and received value when possible.',
       },
     ],
     responseExamples: [
@@ -1434,6 +1451,14 @@ const characterTickets: CharacterTicket[] = [
           },
         },
       },
+      {
+        label: 'Invalid base score',
+        status: '400 Bad Request',
+        payload: {
+          error:
+            'Invalid character ability scores payload: base.DEX must be between 8 and 15 for character levels 1 to 3; received 16',
+        },
+      },
     ],
   },
 ];
@@ -1476,7 +1501,7 @@ function getRequestMethodBadgeClass(value: string) {
 
 function renderDetailValue(value: string) {
   const methodParts = value
-    .split(' and ')
+    .split(/\s*(?:,|and)\s*/g)
     .map((part) => part.trim())
     .filter(Boolean);
 
@@ -1508,7 +1533,7 @@ function renderDetailValue(value: string) {
 function renderMethodBadges(value: string, keyPrefix: string) {
   return (
     <span className="guide-method-badge-row">
-      {value.split(' and ').map((part) => {
+      {value.split(/\s*(?:,|and)\s*/g).map((part) => {
         const trimmedPart = part.trim();
 
         return (

--- a/app/globals.css
+++ b/app/globals.css
@@ -2204,11 +2204,16 @@ li {
   display: inline-flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
+  column-gap: 18px;
+  row-gap: 12px;
 }
 
 .background-guide-card__details .guide-method-badge-row {
   justify-content: center;
+}
+
+.guide-method-badge-row .guide-method-badge + .guide-method-badge {
+  margin-left: 18px;
 }
 
 .guide-method-badge {

--- a/app/lib/character-ability-scores.ts
+++ b/app/lib/character-ability-scores.ts
@@ -3,6 +3,45 @@ import {
   parseCharacterAbilityScores,
 } from '@/app/lib/characters';
 import { getSql } from './db';
+import {
+  CharacterAbilityScores,
+  CharacterAbilityScoresInput,
+  CharacterAbilityScoreRules,
+  CharacterAbilityScoreRuleOption,
+} from '@/app/types/character';
+import { Attributeshortname } from '@/app/types/attribute';
+
+const ABILITY_SCORE_KEYS: Attributeshortname[] = [
+  'STR',
+  'DEX',
+  'CON',
+  'INT',
+  'WIS',
+  'CHA',
+];
+
+const LEVEL_ONE_TO_THREE_BASE_MINIMUM = 8;
+const LEVEL_ONE_TO_THREE_BASE_MAXIMUM = 15;
+const BONUS_MINIMUM = 0;
+const BONUS_MAXIMUM = 2;
+const INVALID_ABILITY_SCORES_ERROR =
+  'Invalid character ability scores payload';
+
+type CharacterAbilityScoresValidationResult =
+  | {
+      valid: true;
+      abilityScores: CharacterAbilityScoresInput;
+    }
+  | {
+      valid: false;
+      error: string;
+    };
+
+interface ValidateCharacterAbilityScoresInputParams {
+  abilityScores: unknown;
+  characterLevel: number;
+  selectionRules: CharacterAbilityScoreRules | null;
+}
 
 function toNumber(value: number | string): number {
   return typeof value === 'number' ? value : Number(value);
@@ -14,6 +53,316 @@ function parseAllowedChoices(value: unknown) {
     : [];
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const valueKeys = Object.keys(value);
+
+  return (
+    valueKeys.length === keys.length &&
+    keys.every((key) => Object.prototype.hasOwnProperty.call(value, key))
+  );
+}
+
+function parseAbilityScores(
+  value: unknown,
+): CharacterAbilityScores | null {
+  if (!isPlainObject(value) || !hasExactKeys(value, ABILITY_SCORE_KEYS)) {
+    return null;
+  }
+
+  if (!ABILITY_SCORE_KEYS.every((key) => Number.isInteger(value[key]))) {
+    return null;
+  }
+
+  return {
+    STR: value.STR as number,
+    DEX: value.DEX as number,
+    CON: value.CON as number,
+    INT: value.INT as number,
+    WIS: value.WIS as number,
+    CHA: value.CHA as number,
+  };
+}
+
+function parseAbilityScoresInput(
+  value: unknown,
+): CharacterAbilityScoresInput | null {
+  if (!isPlainObject(value) || !hasExactKeys(value, ['base', 'bonuses'])) {
+    return null;
+  }
+
+  const base = parseAbilityScores(value.base);
+  const bonuses = parseAbilityScores(value.bonuses);
+
+  return base && bonuses ? { base, bonuses } : null;
+}
+
+function getInvalidBaseScoreMessage(
+  abilityScores: CharacterAbilityScores,
+  characterLevel: number,
+): string | null {
+  if (characterLevel < 1 || characterLevel > 3) {
+    return null;
+  }
+
+  const invalidKey = ABILITY_SCORE_KEYS.find(
+    (key) =>
+      abilityScores[key] < LEVEL_ONE_TO_THREE_BASE_MINIMUM ||
+      abilityScores[key] > LEVEL_ONE_TO_THREE_BASE_MAXIMUM,
+  );
+
+  if (!invalidKey) {
+    return null;
+  }
+
+  return `${INVALID_ABILITY_SCORES_ERROR}: base.${invalidKey} must be between ${LEVEL_ONE_TO_THREE_BASE_MINIMUM} and ${LEVEL_ONE_TO_THREE_BASE_MAXIMUM} for character levels 1 to 3; received ${abilityScores[invalidKey]}`;
+}
+
+function getInvalidBonusRangeMessage(
+  bonuses: CharacterAbilityScores,
+): string | null {
+  const invalidKey = ABILITY_SCORE_KEYS.find(
+    (key) => bonuses[key] < BONUS_MINIMUM || bonuses[key] > BONUS_MAXIMUM,
+  );
+
+  if (!invalidKey) {
+    return null;
+  }
+
+  return `${INVALID_ABILITY_SCORES_ERROR}: bonuses.${invalidKey} must be between ${BONUS_MINIMUM} and ${BONUS_MAXIMUM}; received ${bonuses[invalidKey]}`;
+}
+
+function getDisallowedBonusMessage(
+  bonuses: CharacterAbilityScores,
+  allowedChoices: Attributeshortname[],
+): string | null {
+  const allowedChoiceSet = new Set(allowedChoices);
+  const invalidKey = ABILITY_SCORE_KEYS.find(
+    (key) => bonuses[key] > 0 && !allowedChoiceSet.has(key),
+  );
+
+  if (!invalidKey) {
+    return null;
+  }
+
+  return `${INVALID_ABILITY_SCORES_ERROR}: bonuses.${invalidKey} is not allowed by this character's background. Allowed abilities: ${allowedChoices.join(', ')}`;
+}
+
+function matchesPlusTwoPlusOneRule(
+  bonuses: CharacterAbilityScores,
+  option: Extract<CharacterAbilityScoreRuleOption, { type: 'plus2_plus1' }>,
+): boolean {
+  const positiveBonuses = ABILITY_SCORE_KEYS.filter((key) => bonuses[key] > 0);
+  const expectedPositiveCount = option.choices.reduce(
+    (total, choice) => total + choice.count,
+    0,
+  );
+  const expectedTotalBonus = option.choices.reduce(
+    (total, choice) => total + choice.bonus * choice.count,
+    0,
+  );
+  const actualTotalBonus = ABILITY_SCORE_KEYS.reduce(
+    (total, key) => total + bonuses[key],
+    0,
+  );
+
+  if (
+    positiveBonuses.length !== expectedPositiveCount ||
+    actualTotalBonus !== expectedTotalBonus
+  ) {
+    return false;
+  }
+
+  return option.choices.every((choice) => {
+    const matchingAbilities = ABILITY_SCORE_KEYS.filter(
+      (key) => bonuses[key] === choice.bonus,
+    );
+
+    if (matchingAbilities.length !== choice.count) {
+      return false;
+    }
+
+    if (choice.mustBeDifferentFromBonus === undefined) {
+      return true;
+    }
+
+    return matchingAbilities.every(
+      (key) => bonuses[key] !== choice.mustBeDifferentFromBonus,
+    );
+  });
+}
+
+function matchesPlusOneEachSuggestedRule(
+  bonuses: CharacterAbilityScores,
+  allowedChoices: Attributeshortname[],
+): boolean {
+  const allowedChoiceSet = new Set(allowedChoices);
+
+  return ABILITY_SCORE_KEYS.every((key) =>
+    allowedChoiceSet.has(key) ? bonuses[key] === 1 : bonuses[key] === 0,
+  );
+}
+
+function matchesBonusRule(
+  bonuses: CharacterAbilityScores,
+  selectionRules: CharacterAbilityScoreRules,
+): boolean {
+  const options = selectionRules.bonusRules?.options ?? [];
+
+  return options.some((option) => {
+    if (option.type === 'plus2_plus1') {
+      return matchesPlusTwoPlusOneRule(bonuses, option);
+    }
+
+    if (option.type === 'plus1_each_suggested') {
+      return matchesPlusOneEachSuggestedRule(
+        bonuses,
+        selectionRules.allowedChoices,
+      );
+    }
+
+    return false;
+  });
+}
+
+function describeSelectedBonuses(bonuses: CharacterAbilityScores): string {
+  const selectedBonuses = ABILITY_SCORE_KEYS.filter((key) => bonuses[key] > 0)
+    .map((key) => `${key} +${bonuses[key]}`);
+
+  return selectedBonuses.length > 0 ? selectedBonuses.join(', ') : 'none';
+}
+
+export function validateCharacterAbilityScoresInput({
+  abilityScores,
+  characterLevel,
+  selectionRules,
+}: ValidateCharacterAbilityScoresInputParams): CharacterAbilityScoresValidationResult {
+  const parsedAbilityScores = parseAbilityScoresInput(abilityScores);
+
+  if (!parsedAbilityScores) {
+    return {
+      valid: false,
+      error: `${INVALID_ABILITY_SCORES_ERROR}: abilityScores must contain exactly base and bonuses with integer STR, DEX, CON, INT, WIS, and CHA values`,
+    };
+  }
+
+  if (!selectionRules || !selectionRules.bonusRules) {
+    return {
+      valid: false,
+      error: `${INVALID_ABILITY_SCORES_ERROR}: ability score selection rules are not available for this character`,
+    };
+  }
+
+  const invalidBaseScoreMessage = getInvalidBaseScoreMessage(
+    parsedAbilityScores.base,
+    characterLevel,
+  );
+
+  if (invalidBaseScoreMessage) {
+    return {
+      valid: false,
+      error: invalidBaseScoreMessage,
+    };
+  }
+
+  const invalidBonusRangeMessage = getInvalidBonusRangeMessage(
+    parsedAbilityScores.bonuses,
+  );
+
+  if (invalidBonusRangeMessage) {
+    return {
+      valid: false,
+      error: invalidBonusRangeMessage,
+    };
+  }
+
+  const disallowedBonusMessage = getDisallowedBonusMessage(
+    parsedAbilityScores.bonuses,
+    selectionRules.allowedChoices,
+  );
+
+  if (disallowedBonusMessage) {
+    return {
+      valid: false,
+      error: disallowedBonusMessage,
+    };
+  }
+
+  const hasPlusTwoPlusOneRule = selectionRules.bonusRules.options.some(
+    (option) => option.type === 'plus2_plus1',
+  );
+
+  if (
+    hasPlusTwoPlusOneRule &&
+    !matchesBonusRule(parsedAbilityScores.bonuses, selectionRules)
+  ) {
+    return {
+      valid: false,
+      error: `${INVALID_ABILITY_SCORES_ERROR}: bonuses must follow a +2/+1 split across different allowed abilities; received ${describeSelectedBonuses(parsedAbilityScores.bonuses)}`,
+    };
+  }
+
+  if (!matchesBonusRule(parsedAbilityScores.bonuses, selectionRules)) {
+    return {
+      valid: false,
+      error: `${INVALID_ABILITY_SCORES_ERROR}: bonuses do not match the background ability score rules; received ${describeSelectedBonuses(parsedAbilityScores.bonuses)}`,
+    };
+  }
+
+  return {
+    valid: true,
+    abilityScores: parsedAbilityScores,
+  };
+}
+
+export async function getCharacterAbilityScoreRulesByBackgroundId(
+  backgroundId: number | null,
+): Promise<CharacterAbilityScoreRules | null> {
+  if (backgroundId === null) {
+    return null;
+  }
+
+  const sql = getSql();
+  const backgroundRows = await sql`
+    SELECT id, name, slug, description, abilityscores, feat, skillproficiencies, toolproficiency, equipmentoptions, abilityscorerules
+    FROM backgrounds
+    WHERE id = ${backgroundId}
+    LIMIT 1
+  `;
+
+  if (!backgroundRows || backgroundRows.length === 0) {
+    return null;
+  }
+
+  const background = backgroundRows[0];
+  const backgroundDetails = {
+    id: toNumber(background.id),
+    name: background.name,
+    slug: background.slug,
+    description: background.description,
+    abilityScores: parseAllowedChoices(background.abilityscores),
+    feat: background.feat,
+    skillProficiencies: Array.isArray(background.skillproficiencies)
+      ? background.skillproficiencies
+      : [],
+    toolProficiency: background.toolproficiency ?? null,
+    equipmentOptions: Array.isArray(background.equipmentoptions)
+      ? background.equipmentoptions
+      : [],
+  };
+
+  return getCharacterAbilityScoreRules(
+    backgroundDetails,
+    background.abilityscorerules,
+  );
+}
+
 export async function getCharacterAbilityScoreSelectionContext(
   ownerId: number,
   characterId: number,
@@ -22,6 +371,7 @@ export async function getCharacterAbilityScoreSelectionContext(
   const characterRows = await sql`
     SELECT
       characters.id,
+      characters.level,
       characters.backgroundid,
       characters.abilityscores,
       backgrounds.name AS backgroundname,
@@ -62,6 +412,7 @@ export async function getCharacterAbilityScoreSelectionContext(
 
   return {
     characterId: toNumber(character.id),
+    characterLevel: toNumber(character.level),
     backgroundId,
     backgroundName: character.backgroundname ?? null,
     selectionRules,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adventurers-guild-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adventurers-guild-api",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adventurers-guild-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -58,7 +58,7 @@ const paladinAbilityScores: CharacterAbilityScores = {
 
 const aangAbilityScores: CharacterAbilityScores = {
   STR: 10,
-  DEX: 16,
+  DEX: 15,
   CON: 14,
   INT: 8,
   WIS: 15,
@@ -287,9 +287,9 @@ const paladinArmorClass: CharacterArmorClass = {
 };
 
 const aangArmorClass: CharacterArmorClass = {
-  total: 16,
+  total: 15,
   base: 10,
-  dexModifierApplied: 3,
+  dexModifierApplied: 2,
   classBonus: 3,
   shieldBonus: 0,
   sources: [
@@ -2119,9 +2119,9 @@ test.describe(
         );
         await charactersAssert.validateInitiative(character.initiative, {
           ability: 'DEX',
-          abilityModifier: 3,
+          abilityModifier: 2,
           bonus: 0,
-          total: 3,
+          total: 2,
         });
         await charactersAssert.validatePassivePerception(
           character.passivePerception,
@@ -4264,6 +4264,59 @@ test.describe(
     );
 
     test(
+      'Reject Invalid Drizzt Scores And Keep Previous Scores',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          drizztCharacterId,
+          {
+            abilityScores: {
+              ...drizztAbilityScoresInput,
+              base: {
+                ...drizztAbilityScoresInput.base,
+                DEX: 16,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: base.DEX must be between 8 and 15 for character levels 1 to 3; received 16',
+        );
+
+        const detailResponse = await charactersClient.getCharacterDetail(
+          drizztCharacterId,
+          authToken,
+        );
+
+        await charactersAssert.success(detailResponse);
+
+        const character: CharacterResponseBody = await detailResponse.json();
+
+        await charactersAssert.validateCharacterResponseSchema(character);
+        await charactersAssert.validateName(
+          character.name,
+          drizztCharacterName,
+        );
+        await validateDrizztRangerBuild(character);
+        await charactersAssert.validateAbilityScores(
+          character.abilityScores,
+          drizztAbilityScores,
+          drizztAbilityBonuses,
+        );
+      },
+    );
+
+    test(
       'Clear Scores Drizzt',
       { tag: ['@patch', '@data'] },
       async ({ request }) => {
@@ -6292,6 +6345,303 @@ test.describe(
         await charactersAssert.validateErrorResponse(
           body,
           'Invalid character request payload',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Base Above Creation Maximum',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              base: {
+                ...yenneferAbilityScoresInput.base,
+                STR: 16,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: base.STR must be between 8 and 15 for character levels 1 to 3; received 16',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Base Below Creation Minimum',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              base: {
+                ...yenneferAbilityScoresInput.base,
+                INT: 7,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: base.INT must be between 8 and 15 for character levels 1 to 3; received 7',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Bonus Above Maximum',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              bonuses: {
+                ...yenneferAbilityScoresInput.bonuses,
+                WIS: 3,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: bonuses.WIS must be between 0 and 2; received 3',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Negative Bonus',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              bonuses: {
+                ...yenneferAbilityScoresInput.bonuses,
+                WIS: -1,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: bonuses.WIS must be between 0 and 2; received -1',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Bonus Outside Background Choices',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              bonuses: {
+                STR: 1,
+                DEX: 0,
+                CON: 0,
+                INT: 0,
+                WIS: 0,
+                CHA: 2,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          "Invalid character ability scores payload: bonuses.STR is not allowed by this character's background. Allowed abilities: INT, WIS, CHA",
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Bonus Total Mismatch',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              bonuses: {
+                STR: 0,
+                DEX: 0,
+                CON: 0,
+                INT: 0,
+                WIS: 2,
+                CHA: 0,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: bonuses must follow a +2/+1 split across different allowed abilities; received WIS +2',
+        );
+      },
+    );
+
+    test(
+      'Put Geralt Scores With Incomplete Payload',
+      { tag: ['@put', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacterAbilityScores(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              base: {
+                STR: 15,
+              },
+              bonuses: yenneferAbilityScoresInput.bonuses,
+            } as unknown as CharacterAbilityScoresInput,
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: abilityScores must contain exactly base and bonuses with integer STR, DEX, CON, INT, WIS, and CHA values',
+        );
+      },
+    );
+
+    test(
+      'Patch Geralt Scores With Base Above Creation Maximum',
+      { tag: ['@patch', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.updateCharacter(
+          geraltCharacterId,
+          {
+            abilityScores: {
+              ...yenneferAbilityScoresInput,
+              base: {
+                ...yenneferAbilityScoresInput.base,
+                STR: 16,
+              },
+            },
+          },
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: base.STR must be between 8 and 15 for character levels 1 to 3; received 16',
+        );
+      },
+    );
+
+    test(
+      'Create Geralt With Base Above Creation Maximum',
+      { tag: ['@post', '@negative', '@error', '@ability-scores'] },
+      async ({ request }) => {
+        const charactersClient = new CharactersClient(request);
+        const charactersAssert = new CharactersAssert();
+
+        const response = await charactersClient.createCharacter(
+          buildGeraltWarlockPayload(
+            `Geralt Of Rivia High Score ${Date.now()}`,
+            {
+              abilityScores: {
+                ...yenneferAbilityScoresInput,
+                base: {
+                  ...yenneferAbilityScoresInput.base,
+                  STR: 16,
+                },
+              },
+            },
+          ),
+          authToken,
+        );
+
+        await charactersAssert.badRequest(response);
+
+        const body: { error: string } = await response.json();
+
+        await charactersAssert.validateErrorResponse(
+          body,
+          'Invalid character ability scores payload: base.STR must be between 8 and 15 for character levels 1 to 3; received 16',
         );
       },
     );


### PR DESCRIPTION
## Summary

Strengthens Characters API ability score validation across every endpoint that accepts `abilityScores`.

## What Changed

- Added a shared ability score validator for complete `base` and `bonuses` payloads.
- Enforced level 1 to 3 base score limits of `8` to `15`.
- Enforced bonus limits of `0` to `2`.
- Enforced that positive bonuses can only be applied to abilities allowed by the character's background.
- Enforced the current `+2/+1` split across different allowed abilities.
- Reused the same validation in:
  - `PUT /api/characters/{id}/ability-scores`
  - `PATCH /api/characters/{id}`
  - `POST /api/characters`
- Added clearer `400` error messages that identify the invalid field and received value.
- Added regression tests for invalid ability score attempts.
- Added a flow that confirms invalid updates do not overwrite previously saved scores.
- Updated README and guide documentation with validation rules and error examples.
- Updated the Attributes guide card to show `GET`, `PUT`, and `PATCH`.
- Improved spacing between method badges in the guides UI.

## Why

The API previously validated the basic shape of `abilityScores`, but it did not fully enforce character creation rules.

That meant invalid values could still be persisted, for example:

- base scores above `15`
- base scores below `8`
- bonuses above `2`
- negative bonuses
- bonuses applied to abilities not allowed by the selected background
- invalid bonus distributions that did not follow the `+2/+1` rule

It also meant `POST /api/characters` and `PATCH /api/characters/{id}` could bypass rules expected from the dedicated ability score endpoint.

This PR centralizes the validation so all entry points behave consistently.

## API Behavior

Invalid payloads still return `400`, but the error message is now more helpful.

Example:

```json
{
  "error": "Invalid character ability scores payload: base.DEX must be between 8 and 15 for character levels 1 to 3; received 16"
}
```

Another example:

```json
{
  "error": "Invalid character ability scores payload: bonuses.STR is not allowed by this character's background. Allowed abilities: INT, WIS, CHA"
}
```

The response shape remains unchanged:

```json
{
  "error": "..."
}
```

## Notes For Students

The main lesson in this change is that shared business rules should live in one shared validation path.

Before this PR, multiple endpoints could accept `abilityScores`, but the rules were not enforced consistently. Instead of copying validation logic into every route, this PR adds a reusable validator and calls it from each endpoint.

This keeps the API easier to maintain and reduces the chance that one route accepts invalid data while another route rejects it.

## Validation

Ran:

```txt
npx tsc --noEmit
npm run lint
npx playwright test tests/features/characters.spec.ts
```

Result:

```txt
125 passed
```