### PR TITLE
Update character status docs and preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ This project follows Semantic Versioning while the API is pre-1.0:
 - `MINOR` versions document meaningful API behavior changes, new endpoints, or stricter validation.
 - `PATCH` versions document fixes that do not intentionally change public behavior.
 
+## [0.3.0] - 2026-05-07
+
+### Changed
+
+- Refined character progression status across the Characters API with `draft`, `in_progress`, and `complete`.
+- Updated character completion logic so `complete` now reflects a resolved creation flow instead of only class/species/background presence.
+- Added automatic background skill autofill when `backgroundId` is assigned on character creation or update.
+- Validated class skill choices against class-specific choice counts and allowed class skill options while excluding background-granted skills from that limit.
+- Improved weapon attack derivation for `Finesse`, alternate `attackModes`, and Monk `Unarmed Strike`.
+- Enriched selected spell details returned by character endpoints with spell descriptions.
+
+### Documentation
+
+- Updated README notes for character status semantics, background skill autofill, and class skill proficiency validation.
+- Updated OpenAPI examples and schemas for `abilityScores.bonuses` so they reflect real creation bonus values like `0`, `1`, and `2`.
+
+### Tests
+
+- Expanded character progression coverage for background skill autofill, class skill validation, attack calculations, and completion state expectations.
+
 ## [0.2.0] - 2026-04-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Fantasy-themed REST API built with Next.js to support learning and practice arou
 
 ## Public API Version
 
-Current public API version: `0.2.0`
+Current public API version: `0.3.0`
+
+Current site/package version: `0.3.1`
 
 Public API behavior changes are documented in [CHANGELOG.md](CHANGELOG.md).
 

--- a/app/components/character-preview/character-preview-client.tsx
+++ b/app/components/character-preview/character-preview-client.tsx
@@ -338,6 +338,17 @@ function getErrorMessage(status: number) {
   return 'The character could not be loaded right now.';
 }
 
+function formatCharacterStatusLabel(status: CharacterPreviewResponse['status']) {
+  return status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function getCharacterStatusClassName(status: CharacterPreviewResponse['status']) {
+  return `character-sheet__masthead-status character-sheet__masthead-status--${status}`;
+}
+
 function SheetBlock({
   children,
   className,
@@ -606,8 +617,8 @@ function CharacterSheet({
             <p className="kicker">Character ID</p>
             <h2>#{character.id}</h2>
           </div>
-          <strong className="character-sheet__masthead-status">
-            {character.status}
+          <strong className={getCharacterStatusClassName(character.status)}>
+            {formatCharacterStatusLabel(character.status)}
           </strong>
           <div className="character-sheet__masthead-details">
             <dl>

--- a/app/components/guides/characters-guide-chapter.tsx
+++ b/app/components/guides/characters-guide-chapter.tsx
@@ -74,6 +74,7 @@ const characterCreationSteps = [
     method: 'POST',
     endpoint: '/api/characters',
     note: 'Start the character with the name.',
+    expectedStatus: 'draft',
   },
   {
     step: '2',
@@ -81,6 +82,7 @@ const characterCreationSteps = [
     method: 'PATCH',
     endpoint: '/api/characters/{id}',
     note: 'Choose the class with classId.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '3',
@@ -88,6 +90,7 @@ const characterCreationSteps = [
     method: 'PATCH',
     endpoint: '/api/characters/{id}',
     note: 'Choose the species with speciesId.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '4',
@@ -95,6 +98,7 @@ const characterCreationSteps = [
     method: 'PATCH',
     endpoint: '/api/characters/{id}',
     note: 'Choose the background with backgroundId.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '5',
@@ -102,6 +106,7 @@ const characterCreationSteps = [
     method: 'GET',
     endpoint: '/api/characters/{id}/ability-score-options',
     note: 'Read the rules before choosing the ability scores.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '6',
@@ -109,6 +114,7 @@ const characterCreationSteps = [
     method: 'PUT',
     endpoint: '/api/characters/{id}/ability-scores',
     note: 'Save the chosen ability scores.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '7',
@@ -116,6 +122,7 @@ const characterCreationSteps = [
     method: 'PATCH',
     endpoint: '/api/characters/{id}',
     note: 'Choose extra skill proficiencies when the class allows it.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '8',
@@ -123,6 +130,7 @@ const characterCreationSteps = [
     method: 'POST',
     endpoint: '/api/characters/{id}/equipment/class-choice',
     note: 'Resolve the class equipment package when classEquipmentSelection is pending.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '9',
@@ -130,6 +138,7 @@ const characterCreationSteps = [
     method: 'POST',
     endpoint: '/api/characters/{id}/equipment/background-choice',
     note: 'Resolve the background equipment package when backgroundEquipmentSelection is pending.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '10',
@@ -137,6 +146,7 @@ const characterCreationSteps = [
     method: 'GET',
     endpoint: '/api/characters/{id}/spell-options',
     note: 'Only needed when spellcastingSummary.canCastSpells is true.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '11',
@@ -144,6 +154,7 @@ const characterCreationSteps = [
     method: 'GET',
     endpoint: '/api/characters/{id}/spell-selection',
     note: 'Read the current spell selection before saving changes.',
+    expectedStatus: 'in_progress',
   },
   {
     step: '12',
@@ -151,6 +162,7 @@ const characterCreationSteps = [
     method: 'PUT',
     endpoint: '/api/characters/{id}/spells',
     note: 'Save the chosen spells for the character.',
+    expectedStatus: 'complete',
   },
   {
     step: '13',
@@ -158,6 +170,7 @@ const characterCreationSteps = [
     method: 'GET',
     endpoint: '/api/characters/{id}',
     note: 'Read the final detail response and confirm the current state.',
+    expectedStatus: 'complete',
   },
 ] as const;
 
@@ -214,9 +227,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
+        type: 'draft | in_progress | complete',
         description:
-          'Status becomes complete when missingFields is empty, even if the flow still has pending choices to resolve.',
+          'Creation state for the guided flow: draft before setup starts, in_progress while required steps are unresolved, and complete only when the flow is resolved.',
       },
     ],
     responseExamples: [
@@ -241,7 +254,7 @@ const characterTickets: CharacterTicket[] = [
         payload: {
           id: 101,
           name: 'Merien',
-          status: 'complete',
+          status: 'in_progress',
           missingFields: [],
           pendingChoices: [
             'classEquipmentSelection',
@@ -292,8 +305,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
-        description: 'Current setup state of the character.',
+        type: 'draft | in_progress | complete',
+        description:
+          'Current creation state of the character for list views.',
       },
       {
         name: 'level',
@@ -320,6 +334,12 @@ const characterTickets: CharacterTicket[] = [
           {
             id: 102,
             name: 'Arin',
+            status: 'in_progress',
+            level: 2,
+          },
+          {
+            id: 103,
+            name: 'Lyra',
             status: 'complete',
             level: 3,
           },
@@ -481,8 +501,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
-        description: 'Current setup state of the selected character.',
+        type: 'draft | in_progress | complete',
+        description:
+          'Current creation state of the selected character.',
       },
       {
         name: 'level',
@@ -576,9 +597,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
+        type: 'draft | in_progress | complete',
         description:
-          'The character can still remain draft if other important fields are missing.',
+          'Becomes in_progress after creation has started but required steps are still unresolved.',
       },
     ],
     responseExamples: [
@@ -595,7 +616,7 @@ const characterTickets: CharacterTicket[] = [
         payload: {
           id: 101,
           name: 'Merien',
-          status: 'draft',
+          status: 'in_progress',
           classId: 12,
           speciesId: null,
           backgroundId: null,
@@ -652,9 +673,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
+        type: 'draft | in_progress | complete',
         description:
-          'The character can still remain draft if other important fields are missing.',
+          'Remains in_progress while required structure or later creation steps are unresolved.',
       },
     ],
     responseExamples: [
@@ -671,7 +692,7 @@ const characterTickets: CharacterTicket[] = [
         payload: {
           id: 101,
           name: 'Merien',
-          status: 'draft',
+          status: 'in_progress',
           classId: 12,
           speciesId: 3,
           backgroundId: null,
@@ -738,9 +759,9 @@ const characterTickets: CharacterTicket[] = [
       },
       {
         name: 'status',
-        type: 'draft | complete',
+        type: 'draft | in_progress | complete',
         description:
-          'Once backgroundId is filled, status can already become complete even if equipment choices are still pending.',
+          'Usually remains in_progress after background selection until ability scores, required choices, equipment packages, skills, and spells are resolved.',
       },
     ],
     responseExamples: [
@@ -757,7 +778,7 @@ const characterTickets: CharacterTicket[] = [
         payload: {
           id: 101,
           name: 'Merien',
-          status: 'complete',
+          status: 'in_progress',
           classId: 12,
           speciesId: 3,
           backgroundId: 13,
@@ -1632,6 +1653,28 @@ function renderEndpointPath(value: string) {
   );
 }
 
+function renderFlowRequest(item: (typeof characterCreationSteps)[number]) {
+  return (
+    <div className="characters-flow-table__request">
+      {renderMethodBadges(item.method, item.step)}
+      {renderEndpointPath(item.endpoint)}
+    </div>
+  );
+}
+
+function renderExpectedStatus(status: (typeof characterCreationSteps)[number]['expectedStatus']) {
+  const label = status
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  return (
+    <code className={`characters-flow-table__status characters-flow-table__status--${status}`}>
+      {label}
+    </code>
+  );
+}
+
 export function CharactersGuideChapter({
   isOpen,
   onClose,
@@ -1699,7 +1742,6 @@ export function CharactersGuideChapter({
             once in a single <code>POST</code> request or gradually by choosing
             character details step by step.
           </p>
-
           <section className="guide-expected-return">
             <div className="section-heading">
               <h3>Create flow</h3>
@@ -1707,7 +1749,7 @@ export function CharactersGuideChapter({
               <p>
                 This table shows the happy path before the chapter details
                 below. It helps the user understand which request usually comes
-                next during character creation.
+                next and which character status to expect after each step.
               </p>
             </div>
 
@@ -1718,8 +1760,8 @@ export function CharactersGuideChapter({
                     <th scope="col">Step</th>
                     <th scope="col">Action</th>
                     <th scope="col">What happens</th>
-                    <th scope="col">Request type</th>
-                    <th scope="col">Path</th>
+                    <th scope="col">Request</th>
+                    <th scope="col">Expected status</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -1728,8 +1770,10 @@ export function CharactersGuideChapter({
                       <td>{item.step}</td>
                       <td>{item.title}</td>
                       <td>{item.note}</td>
-                      <td>{renderMethodBadges(item.method, item.step)}</td>
-                      <td>{renderEndpointPath(item.endpoint)}</td>
+                      <td>{renderFlowRequest(item)}</td>
+                      <td>
+                        {renderExpectedStatus(item.expectedStatus)}
+                      </td>
                     </tr>
                   ))}
                 </tbody>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2437,20 +2437,69 @@ li {
 }
 
 .characters-flow-table td:first-child {
-  width: 90px;
+  width: 64px;
 }
 
 .characters-flow-table .guide-method-badge-row {
   justify-content: center;
 }
 
+.characters-flow-table__request {
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  min-width: 220px;
+}
+
+.characters-flow-table__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  min-width: 96px;
+  padding: 5px 12px;
+  border: 1px solid rgba(90, 42, 26, 0.22);
+  border-radius: 999px;
+  color: #5a2a1a;
+  font-family: var(--font-heading), serif;
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.36),
+    0 7px 14px rgba(45, 20, 12, 0.08);
+}
+
+.characters-flow-table__status--draft {
+  border-color: rgba(122, 42, 34, 0.38);
+  background: linear-gradient(180deg, rgba(248, 202, 188, 0.92), rgba(209, 111, 91, 0.72));
+  color: #60241c;
+}
+
+.characters-flow-table__status--in_progress {
+  border-color: rgba(148, 83, 27, 0.42);
+  background: linear-gradient(180deg, rgba(255, 219, 157, 0.94), rgba(222, 148, 64, 0.74));
+  color: #643611;
+}
+
+.characters-flow-table__status--complete {
+  border-color: rgba(63, 112, 61, 0.42);
+  background: linear-gradient(180deg, rgba(207, 235, 178, 0.94), rgba(126, 178, 97, 0.74));
+  color: #294f24;
+}
+
 .characters-flow-table__path {
   display: inline-block;
+  max-width: 100%;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-  white-space: nowrap;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .characters-flow-table__path-param {
@@ -4008,6 +4057,38 @@ li {
   box-shadow:
     inset 0 1px 0 rgba(255, 211, 160, 0.22),
     0 8px 16px rgba(77, 18, 15, 0.22);
+}
+
+.character-sheet__masthead-status--in_progress {
+  border-color: rgba(255, 219, 143, 0.28);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(255, 225, 148, 0.24),
+      transparent 34%
+    ),
+    linear-gradient(180deg, #c98224 0%, #7a4314 100%);
+  color: #fff0bf;
+  text-shadow: 0 1px 0 rgba(82, 42, 8, 0.72);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 236, 177, 0.24),
+    0 8px 16px rgba(114, 61, 16, 0.2);
+}
+
+.character-sheet__masthead-status--complete {
+  border-color: rgba(190, 225, 164, 0.24);
+  background:
+    radial-gradient(
+      circle at top left,
+      rgba(190, 225, 164, 0.18),
+      transparent 34%
+    ),
+    linear-gradient(180deg, #315f2d 0%, #183716 100%);
+  color: #e9f6cf;
+  text-shadow: 0 1px 0 rgba(13, 38, 11, 0.8);
+  box-shadow:
+    inset 0 1px 0 rgba(218, 242, 188, 0.18),
+    0 8px 16px rgba(20, 58, 18, 0.24);
 }
 
 .character-sheet__identity,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "adventurers-guild-api",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "adventurers-guild-api",
-      "version": "0.2.0",
+      "version": "0.3.1",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",
         "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adventurers-guild-api",
-  "version": "0.2.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 
 info:
   title: Adventurers Guild API
-  version: 1.20.0
+  version: 0.3.0
   description: |
     Fantasy-themed API designed for backend testing, API automation, and contract validation practice.
 

--- a/tests/features/characters.spec.ts
+++ b/tests/features/characters.spec.ts
@@ -6247,158 +6247,159 @@ test.describe(
   'Characters API - Background Skill Autofill Coverage',
   { tag: ['@characters', '@skills', '@backgrounds', '@coverage'] },
   () => {
-    test('Autofill background skills and merge chosen class skills', async ({
-      request,
-    }) => {
-      const charactersClient = new CharactersClient(request);
-      const charactersAssert = new CharactersAssert();
-      const authToken = await issueDemoToken(request);
-      const coverageCases: {
-        label: string;
-        classId: number;
-        speciesId: number;
-        backgroundId: number;
-        expectedBackgroundSkills: SkillName[];
-        extraSkillChoices: SkillName[];
-        expectedFinalSkills: SkillName[];
-      }[] = [
-        {
-          label: 'Monk Acolyte',
-          classId: 6,
-          speciesId: 7,
-          backgroundId: 1,
-          expectedBackgroundSkills:
-            expectedDetailedBackgrounds.acolyte.skillProficiencies as SkillName[],
-          extraSkillChoices: monkExtraSkillProficiencies,
-          expectedFinalSkills: monkSkillProficiencies,
-        },
-        {
-          label: 'Paladin Noble',
-          classId: 7,
-          speciesId: 7,
-          backgroundId: 12,
-          expectedBackgroundSkills:
-            expectedDetailedBackgrounds.noble.skillProficiencies as SkillName[],
-          extraSkillChoices: paladinExtraSkillProficiencies,
-          expectedFinalSkills: paladinSkillProficiencies,
-        },
-        {
-          label: 'Ranger Soldier',
-          classId: 8,
-          speciesId: 3,
-          backgroundId: 16,
-          expectedBackgroundSkills:
-            expectedDetailedBackgrounds.soldier.skillProficiencies as SkillName[],
-          extraSkillChoices: rangerExtraSkillProficiencies,
-          expectedFinalSkills: rangerSkillProficiencies,
-        },
-        {
-          label: 'Rogue Criminal',
-          classId: 9,
-          speciesId: 7,
-          backgroundId: 5,
-          expectedBackgroundSkills:
-            expectedDetailedBackgrounds.criminal.skillProficiencies as SkillName[],
-          extraSkillChoices: rogueExtraSkillProficiencies,
-          expectedFinalSkills: rogueSkillProficiencies,
-        },
-        {
-          label: 'Fighter Soldier',
-          classId: 5,
-          speciesId: 7,
-          backgroundId: 16,
-          expectedBackgroundSkills:
-            expectedDetailedBackgrounds.soldier.skillProficiencies as SkillName[],
-          extraSkillChoices: fighterExtraSkillProficiencies,
-          expectedFinalSkills: fighterSkillProficiencies,
-        },
-      ];
+    const coverageCases: {
+      label: string;
+      classId: number;
+      speciesId: number;
+      backgroundId: number;
+      expectedBackgroundSkills: SkillName[];
+      extraSkillChoices: SkillName[];
+      expectedFinalSkills: SkillName[];
+    }[] = [
+      {
+        label: 'Monk Acolyte',
+        classId: 6,
+        speciesId: 7,
+        backgroundId: 1,
+        expectedBackgroundSkills:
+          expectedDetailedBackgrounds.acolyte.skillProficiencies as SkillName[],
+        extraSkillChoices: monkExtraSkillProficiencies,
+        expectedFinalSkills: monkSkillProficiencies,
+      },
+      {
+        label: 'Paladin Noble',
+        classId: 7,
+        speciesId: 7,
+        backgroundId: 12,
+        expectedBackgroundSkills:
+          expectedDetailedBackgrounds.noble.skillProficiencies as SkillName[],
+        extraSkillChoices: paladinExtraSkillProficiencies,
+        expectedFinalSkills: paladinSkillProficiencies,
+      },
+      {
+        label: 'Ranger Soldier',
+        classId: 8,
+        speciesId: 3,
+        backgroundId: 16,
+        expectedBackgroundSkills:
+          expectedDetailedBackgrounds.soldier.skillProficiencies as SkillName[],
+        extraSkillChoices: rangerExtraSkillProficiencies,
+        expectedFinalSkills: rangerSkillProficiencies,
+      },
+      {
+        label: 'Rogue Criminal',
+        classId: 9,
+        speciesId: 7,
+        backgroundId: 5,
+        expectedBackgroundSkills:
+          expectedDetailedBackgrounds.criminal.skillProficiencies as SkillName[],
+        extraSkillChoices: rogueExtraSkillProficiencies,
+        expectedFinalSkills: rogueSkillProficiencies,
+      },
+      {
+        label: 'Fighter Soldier',
+        classId: 5,
+        speciesId: 7,
+        backgroundId: 16,
+        expectedBackgroundSkills:
+          expectedDetailedBackgrounds.soldier.skillProficiencies as SkillName[],
+        extraSkillChoices: fighterExtraSkillProficiencies,
+        expectedFinalSkills: fighterSkillProficiencies,
+      },
+    ];
 
-      const createdCharacterIds: number[] = [];
+    for (const coverageCase of coverageCases) {
+      test(
+        `Autofill background skills and merge chosen class skills - ${coverageCase.label}`,
+        async ({ request }) => {
+          const charactersClient = new CharactersClient(request);
+          const charactersAssert = new CharactersAssert();
+          const authToken = await issueDemoToken(request);
+          let createdCharacterId: number | null = null;
 
-      try {
-        for (const coverageCase of coverageCases) {
-          const createResponse = await charactersClient.createCharacter(
-            {
-              name: `${coverageCase.label} ${Date.now()}`,
-              classId: coverageCase.classId,
-              speciesId: coverageCase.speciesId,
-              backgroundId: coverageCase.backgroundId,
-              level: 1,
-            },
-            authToken,
-          );
+          try {
+            const createResponse = await charactersClient.createCharacter(
+              {
+                name: `${coverageCase.label} ${Date.now()}`,
+                classId: coverageCase.classId,
+                speciesId: coverageCase.speciesId,
+                backgroundId: coverageCase.backgroundId,
+                level: 1,
+              },
+              authToken,
+            );
 
-          await charactersAssert.created(createResponse);
+            await charactersAssert.created(createResponse);
 
-          const createdCharacter: CharacterResponseBody =
-            await createResponse.json();
-          createdCharacterIds.push(createdCharacter.id);
+            const createdCharacter: CharacterResponseBody =
+              await createResponse.json();
+            createdCharacterId = createdCharacter.id;
 
-          await test.step(
-            `Validate background skills are auto-applied for ${coverageCase.label}`,
-            async () => {
-              await charactersAssert.validateSkillProficiencies(
-                createdCharacter.skillProficiencies,
-                coverageCase.expectedBackgroundSkills,
+            await test.step(
+              `Validate background skills are auto-applied for ${coverageCase.label}`,
+              async () => {
+                await charactersAssert.validateSkillProficiencies(
+                  createdCharacter.skillProficiencies,
+                  coverageCase.expectedBackgroundSkills,
+                );
+              },
+            );
+
+            const patchSkillsResponse = await charactersClient.updateCharacter(
+              createdCharacter.id,
+              {
+                skillProficiencies: coverageCase.extraSkillChoices,
+              },
+              authToken,
+            );
+
+            await charactersAssert.success(patchSkillsResponse);
+
+            const updatedCharacter: CharacterResponseBody =
+              await patchSkillsResponse.json();
+
+            await test.step(
+              `Validate chosen skills merge with background skills for ${coverageCase.label}`,
+              async () => {
+                await charactersAssert.validateSkillProficiencies(
+                  updatedCharacter.skillProficiencies,
+                  coverageCase.expectedFinalSkills,
+                );
+              },
+            );
+
+            const detailResponse = await charactersClient.getCharacterDetail(
+              createdCharacter.id,
+              authToken,
+            );
+
+            await charactersAssert.success(detailResponse);
+
+            const detailedCharacter: CharacterResponseBody =
+              await detailResponse.json();
+
+            await test.step(
+              `Validate final detail keeps merged skills for ${coverageCase.label}`,
+              async () => {
+                await charactersAssert.validateSkillProficiencies(
+                  detailedCharacter.skillProficiencies,
+                  coverageCase.expectedFinalSkills,
+                );
+              },
+            );
+          } finally {
+            if (createdCharacterId !== null) {
+              const deleteResponse = await charactersClient.deleteCharacter(
+                createdCharacterId,
+                authToken,
               );
-            },
-          );
 
-          const patchSkillsResponse = await charactersClient.updateCharacter(
-            createdCharacter.id,
-            {
-              skillProficiencies: coverageCase.extraSkillChoices,
-            },
-            authToken,
-          );
-
-          await charactersAssert.success(patchSkillsResponse);
-
-          const updatedCharacter: CharacterResponseBody =
-            await patchSkillsResponse.json();
-
-          await test.step(
-            `Validate chosen skills merge with background skills for ${coverageCase.label}`,
-            async () => {
-              await charactersAssert.validateSkillProficiencies(
-                updatedCharacter.skillProficiencies,
-                coverageCase.expectedFinalSkills,
-              );
-            },
-          );
-
-          const detailResponse = await charactersClient.getCharacterDetail(
-            createdCharacter.id,
-            authToken,
-          );
-
-          await charactersAssert.success(detailResponse);
-
-          const detailedCharacter: CharacterResponseBody =
-            await detailResponse.json();
-
-          await test.step(
-            `Validate final detail keeps merged skills for ${coverageCase.label}`,
-            async () => {
-              await charactersAssert.validateSkillProficiencies(
-                detailedCharacter.skillProficiencies,
-                coverageCase.expectedFinalSkills,
-              );
-            },
-          );
-        }
-      } finally {
-        for (const characterId of createdCharacterIds) {
-          const deleteResponse = await charactersClient.deleteCharacter(
-            characterId,
-            authToken,
-          );
-
-          expect(deleteResponse.ok()).toBe(true);
-        }
-      }
-    });
+              expect(deleteResponse.ok()).toBe(true);
+            }
+          }
+        },
+      );
+    }
 
     test('Reject invalid class skill selections for Barbarian', async ({
       request,


### PR DESCRIPTION
## Summary

- Updated the Characters guide flow table to show the expected character status after each request.
- Moved the request method and API path into a compact single column to avoid horizontal overflow.
- Added status color treatment for `draft`, `in_progress`, and `complete` in the guide table.
- Updated the character preview masthead status colors while preserving the existing badge style.
- Bumped the site/package version to `0.3.1` while keeping the public API version at `0.3.0`.

## Validation

- Ran `npm run lint`
